### PR TITLE
removed duplicate matlambda(0,0) from being set twice to 1e3

### DIFF
--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -5363,7 +5363,6 @@ void Optimizer::OptimizeEssentialGraph4DoF(Map* pMap, KeyFrame* pLoopKF, KeyFram
     Eigen::Matrix<double,6,6> matLambda = Eigen::Matrix<double,6,6>::Identity();
     matLambda(0,0) = 1e3;
     matLambda(1,1) = 1e3;
-    matLambda(0,0) = 1e3;
 
     // Set Loop edges
     Edge4DoF* e_loop;


### PR DESCRIPTION
After creating an identity matrix, the authors set the first two values of the matrix diagonal to 1e3, and then set the first value of the matrix diagonal to 1e3 again. Upon looking at the code and where the matrix is used in https://github.com/Soldann/MORB_SLAM/blob/master/Thirdparty/g2o/g2o/core/optimizable_graph.cpp, there doesn't seem to be an explicit reason as to why the diagonal of the matrix was changed, as they only checked the matrix to make sure that the matrix was a symmetric positive definite matrix. For now, the duplicate line was removed.