### PR TITLE
Changed condition to set pKFm

### DIFF
--- a/src/Sim3Solver.cc
+++ b/src/Sim3Solver.cc
@@ -81,7 +81,7 @@ Sim3Solver::Sim3Solver(KeyFrame *pKF1, KeyFrame *pKF2, const vector<MapPoint *> 
             if(pMP1->isBad() || pMP2->isBad())
                 continue;
 
-            if(bDifferentKFs)
+            if(!bDifferentKFs)
                 pKFm = vpKeyFrameMatchedMP[i1];
 
             int indexKF1 = get<0>(pMP1->GetIndexInKeyFrame(pKF1));


### PR DESCRIPTION
The solution proposed for https://github.com/Soldann/MORB_SLAM/issues/13#issue-1286161847 involved switching ```bDifferentKFs``` to be initially set to true and would then be switched to false if ```vpKeyFrameMatchedMp``` was empty. However, this technically isn't correct as an empty ```vpKeyFrameMatchedMp``` insinuates that it is a different key frame. Thus, https://github.com/Soldann/MORB_SLAM/blob/f3c8f3cba4d704030dbeab1b631199b037d912a5/src/Sim3Solver.cc#L84 was changed to only set ```pKFm``` if it isn't a different frame. Otherwise, the default ```pKFm``` value of ```pKF2``` is used instead.