### PR TITLE
Changed _jacobian0plus[7] so use scaling factor

### DIFF
--- a/src/G2oTypes.cc
+++ b/src/G2oTypes.cc
@@ -713,8 +713,8 @@ void EdgeInertialGS::linearizeOplus()
 
     // Jacobians wrt scale factor
     _jacobianOplus[7].setZero();
-    _jacobianOplus[7].block<3,1>(3,0) = Rbw1*(VV2->estimate()-VV1->estimate());
-    _jacobianOplus[7].block<3,1>(6,0) = Rbw1*(VP2->estimate().twb-VP1->estimate().twb-VV1->estimate()*dt);
+    _jacobianOplus[7].block<3,1>(3,0) = s*Rbw1*(VV2->estimate()-VV1->estimate());
+    _jacobianOplus[7].block<3,1>(6,0) = s*Rbw1*(VP2->estimate().twb-VP1->estimate().twb-VV1->estimate()*dt);
 }
 
 EdgePriorPoseImu::EdgePriorPoseImu(ConstraintPoseImu *c)


### PR DESCRIPTION
Note: Testing will be needed to ensure functionality

```_jacobian0plus[7]``` is now multiplied by scaling factor ```s``` as reported in https://github.com/UZ-SLAMLab/ORB_SLAM3/issues/191#issue-748534653. It seems that this was also bought up in a separate issue and the authors forgot to add this change.