### PR TITLE
Fix: segfault when shutting down and no active map in atlas

### DIFF
--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -1724,7 +1724,10 @@ void Tracking::Track() {
 
   Map* pCurrentMap = mpAtlas->GetCurrentMap(mpSystem);
   if (!pCurrentMap) {
-    cout << "ERROR: There is not an active map in the atlas" << endl;
+    if (!mpSystem->isShutDown()){
+      cout << "ERROR: There is not an active map in the atlas" << endl;
+    }
+    return;
   }
 
   if (mState != NO_IMAGES_YET) {


### PR DESCRIPTION
# Description & Motivation

Fixes #57 

This fixes the segmentation fault that occurs when there is no active map in the atlas when shutting down.

# Changes made

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

The program would recognize the map doesn't exist but proceed regardless and segfault. This change aborts the relevant function so the program proceeds as expected.

# Test Plan

Confirmed that no segfault occurred even when the ERROR was printed
**Test Configuration**:
* Hardware: Laptop
