### PR TITLE
Enable emitter for additional depth info

### DIFF
--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
             if (index == 1) {
                 sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, 1);
                 sensor.set_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT,5000);
-                sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 0); // switch off emitter
+                sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 1); // emitter on for depth information
             }
             // std::cout << "  " << index << " : " << sensor.get_info(RS2_CAMERA_INFO_NAME) << std::endl;
             get_sensor_option(sensor);


### PR DESCRIPTION
# Description & Motivation

Fixes https://github.com/Soldann/MORB_SLAM/issues/60

Enabled the IR projector in the stereo-inertial example for the Intel Realsense d435i https://github.com/Soldann/MORB_SLAM/blob/ccd5d4cb1645dcd20fe5f2f3d3c623c506100238/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc

# Changes made

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

Changed ```sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 0);``` to ```sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 1);```
https://github.com/Soldann/MORB_SLAM/blob/ccd5d4cb1645dcd20fe5f2f3d3c623c506100238/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc#L143

# Test Plan

Will need to run a test with **_MORB_SLAM_** in order to ensure proper depth functionality.

Test Configuration:

    Hardware: @Ryan-Red Device

Will eventually conduct a second test once pose extraction is running in order to compare pose accuracy

Test Configuration:

    Hardware: Jetson Orin (preferably) or other

