### PR TITLE
Viewer Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(MORB_SLAM VERSION 1.0 LANGUAGES CXX)
 #   SET(CMAKE_BUILD_TYPE Release)
 # ENDIF()
 
-MESSAGE("Build type: " ${CMAKE_BUILD_TYPE})
+MESSAGE(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -Wall   -O3")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall   -O3")
@@ -29,8 +29,8 @@ find_package(OpenCV 4.4)
       message(FATAL_ERROR "OpenCV > 4.4 not found.")
    endif()
 
-MESSAGE("OPENCV VERSION:")
-MESSAGE(${OpenCV_VERSION})
+MESSAGE(STATUS "OPENCV VERSION:")
+MESSAGE(STATUS ${OpenCV_VERSION})
 
 find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
@@ -219,7 +219,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
         target_link_libraries(rgbd_inertial_realsense_D435i ${PROJECT_NAME})
         endif()
 
-        #Stereo examples
+        # #Stereo examples
         set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/Stereo)
 
         add_executable(stereo_kitti
@@ -315,6 +315,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
         target_link_libraries(stereo_inertial_realsense_D435i ${PROJECT_NAME})
         endif()
 
+        # Calibration examples
         set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/Calibration)
         if(realsense2_FOUND)
         add_executable(recorder_realsense_D435i

--- a/Examples/Calibration/recorder_realsense_D435i.cc
+++ b/Examples/Calibration/recorder_realsense_D435i.cc
@@ -28,8 +28,7 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
@@ -267,11 +266,11 @@ int main(int argc, char **argv) {
         //assert(vAccel.size() == vAccel_times.size());
         //assert(vGyro.size() == vGyro_times.size());
 
-        for(int i=0; i<vAccel.size(); ++i){
+        for(size_t i=0; i<vAccel.size(); ++i){
             accFile << std::setprecision(15) << vAccel_times[i] << "," << vAccel[i].x << "," << vAccel[i].y << "," << vAccel[i].z << endl;
         }
 
-        for(int i=0; i<vGyro.size(); ++i){
+        for(size_t i=0; i<vGyro.size(); ++i){
             gyroFile << std::setprecision(15) << vGyro_times[i] << "," << vGyro[i].x << "," << vGyro[i].y << "," << vGyro[i].z << endl;
         }
 

--- a/Examples/Calibration/recorder_realsense_T265.cc
+++ b/Examples/Calibration/recorder_realsense_T265.cc
@@ -28,8 +28,7 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/opencv.hpp>
 #include "opencv2/imgproc/imgproc.hpp"
 
 #include <librealsense2/rs.hpp>
@@ -49,6 +48,7 @@ void exit_loop_handler(int s){
     b_continue_session = false;
 }
 
+/* // UNUSED
 static rs2_option get_sensor_option(const rs2::sensor& sensor)
 {
     // Sensors usually have several options to control their properties
@@ -90,6 +90,7 @@ static rs2_option get_sensor_option(const rs2::sensor& sensor)
     uint32_t selected_sensor_option = 0;
     return static_cast<rs2_option>(selected_sensor_option);
 }
+*/
 
 int main(int argc, char **argv) {
 
@@ -266,11 +267,11 @@ int main(int argc, char **argv) {
         //assert(vAccel.size() == vAccel_times.size());
         //assert(vGyro.size() == vGyro_times.size());
 
-        for(int i=0; i<vAccel.size(); ++i){
+        for(size_t i=0; i<vAccel.size(); ++i){
             accFile << std::setprecision(15) << vAccel_times[i] << "," << vAccel[i].x << "," << vAccel[i].y << "," << vAccel[i].z << endl;
         }
 
-        for(int i=0; i<vGyro.size(); ++i){
+        for(size_t i=0; i<vGyro.size(); ++i){
             gyroFile << std::setprecision(15) << vGyro_times[i] << "," << vGyro[i].x << "," << vGyro[i].y << "," << vGyro[i].z << endl;
         }
 

--- a/Examples/Monocular-Inertial/mono_inertial_euroc.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_euroc.cc
@@ -24,9 +24,10 @@
 #include <ctime>
 #include <sstream>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 #include "ImuTypes.h"
 
 using namespace std;
@@ -117,12 +118,14 @@ int main(int argc, char *argv[])
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     int proccIm=0;
     for (seq = 0; seq<num_seq; seq++)
     {
@@ -156,7 +159,7 @@ int main(int argc, char *argv[])
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -180,13 +183,13 @@ int main(int argc, char *argv[])
 
             // Pass the image to the SLAM system
             // cout << "tframe = " << tframe << endl;
-            SLAM.TrackMonocular(im,tframe,vImuMeas); // TODO change to monocular_inertial
+            auto pos = SLAM->TrackMonocular(im,tframe,vImuMeas); // TODO change to monocular_inertial
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
-
+            viewer.update(pos);
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
             double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -209,25 +212,25 @@ int main(int argc, char *argv[])
         {
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
     }
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Save camera trajectory
     if (bFileName)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     return 0;

--- a/Examples/Monocular-Inertial/mono_inertial_euroc.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_euroc.cc
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_MONOCULAR, true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;

--- a/Examples/Monocular-Inertial/mono_inertial_realsense_D435i.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_realsense_D435i.cc
@@ -287,7 +287,7 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_MONOCULAR, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double timestamp;

--- a/Examples/Monocular-Inertial/mono_inertial_realsense_D435i.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_realsense_D435i.cc
@@ -27,12 +27,13 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -287,8 +288,9 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     double timestamp;
     cv::Mat im;
@@ -299,10 +301,11 @@ int main(int argc, char **argv) {
     v_accel_data_sync.clear();
     v_accel_timestamp_sync.clear();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
-    while (!SLAM.isShutDown())
+#endif
+    while (viewer.isOpen())
     {
         std::vector<rs2_vector> vGyro;
         std::vector<double> vGyro_times;
@@ -314,7 +317,7 @@ int main(int argc, char **argv) {
             if(!image_ready)
                 cond_image_rec.wait(lk);
 
-            std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now();
+            // std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now(); // UNUSED
 
 
             if(count_im_buffer>1)
@@ -351,7 +354,7 @@ int main(int argc, char **argv) {
         }
 
 
-        for(int i=0; i<vGyro.size(); ++i)
+        for(size_t i=0; i<vGyro.size(); ++i)
         {
             ORB_SLAM3::IMU::Point lastPoint(vAccel[i].x, vAccel[i].y, vAccel[i].z,
                                   vGyro[i].x, vGyro[i].y, vGyro[i].z,
@@ -370,7 +373,7 @@ int main(int argc, char **argv) {
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
@@ -378,13 +381,13 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Pass the image to the SLAM system
-        SLAM.TrackMonocular(im, timestamp, vImuMeas);
+        auto pos = SLAM->TrackMonocular(im, timestamp, vImuMeas);
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
-
+        viewer.update(pos);
 
 
         // Clear the previous IMU measurements to load the new ones

--- a/Examples/Monocular-Inertial/mono_inertial_realsense_t265.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_realsense_t265.cc
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
         bFileName = true;
     }
 
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_MONOCULAR, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     struct sigaction sigIntHandler;

--- a/Examples/Monocular-Inertial/mono_inertial_tum_vi.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_tum_vi.cc
@@ -23,9 +23,10 @@
 #include <ctime>
 #include <sstream>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 #include "ImuTypes.h"
 
 using namespace std;
@@ -116,12 +117,14 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     int proccIm = 0;
     for (seq = 0; seq<num_seq; seq++)
     {
@@ -180,7 +183,7 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -191,13 +194,13 @@ int main(int argc, char **argv)
 
             // Pass the image to the SLAM system
             // cout << "tframe = " << tframe << endl;
-            SLAM.TrackMonocular(im,tframe,vImuMeas); // TODO change to monocular_inertial
+            auto pos = SLAM->TrackMonocular(im,tframe,vImuMeas); // TODO change to monocular_inertial
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
-
+            viewer.update(pos);
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
             double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -221,14 +224,14 @@ int main(int argc, char **argv)
         {
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
 
     }
 
     // cout << "ttrack_tot = " << ttrack_tot << std::endl;
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
 
     // Tracking time statistics
@@ -239,13 +242,13 @@ int main(int argc, char **argv)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     sort(vTimesTrack.begin(),vTimesTrack.end());
@@ -261,8 +264,8 @@ int main(int argc, char **argv)
     /*const string kf_file =  "kf_" + ss.str() + ".txt";
     const string f_file =  "f_" + ss.str() + ".txt";
 
-    SLAM.SaveTrajectoryEuRoC(f_file);
-    SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);*/
+    SLAM->SaveTrajectoryEuRoC(f_file);
+    SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);*/
 
     return 0;
 }

--- a/Examples/Monocular-Inertial/mono_inertial_tum_vi.cc
+++ b/Examples/Monocular-Inertial/mono_inertial_tum_vi.cc
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_MONOCULAR, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_MONOCULAR, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;

--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -21,9 +21,10 @@
 #include<fstream>
 #include<chrono>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 
 using namespace std;
 
@@ -77,15 +78,17 @@ int main(int argc, char **argv)
     cout.precision(17);
 
 
-    int fps = 20;
-    float dT = 1.f/fps;
+    // int fps = 20; // UNUSED
+    // float dT = 1.f/fps; // UNUSED
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, false);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     for (seq = 0; seq<num_seq; seq++)
     {
 
@@ -119,7 +122,7 @@ int main(int argc, char **argv)
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
 
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -128,14 +131,15 @@ int main(int argc, char **argv)
 
             // Pass the image to the SLAM system
             // cout << "tframe = " << tframe << endl;
-            SLAM.TrackMonocular(im,tframe); // TODO change to monocular_inertial
+            auto pos = SLAM->TrackMonocular(im,tframe); // TODO change to monocular_inertial
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
 
+            viewer.update(pos);
 
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
             double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -162,30 +166,30 @@ int main(int argc, char **argv)
         {
             string kf_file_submap =  "./SubMaps/kf_SubMap_" + std::to_string(seq) + ".txt";
             string f_file_submap =  "./SubMaps/f_SubMap_" + std::to_string(seq) + ".txt";
-            SLAM.SaveTrajectoryEuRoC(f_file_submap);
-            SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file_submap);
+            SLAM->SaveTrajectoryEuRoC(f_file_submap);
+            SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file_submap);
 
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
 
     }
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Save camera trajectory
     if (bFileName)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     return 0;

--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
     int fps = 20;
     float dT = 1.f/fps;
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR, false);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, false);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;

--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
     int nImages = vstrImageFilenames.size();
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR,true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR,true);
     float imageScale = SLAM.GetImageScale();
 
     // Vector for tracking time statistics

--- a/Examples/Monocular/mono_realsense_D435i.cc
+++ b/Examples/Monocular/mono_realsense_D435i.cc
@@ -207,7 +207,7 @@ int main(int argc, char **argv) {
     std::cout << " Model = " << intrinsics_left.model << std::endl;
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double timestamp;

--- a/Examples/Monocular/mono_realsense_D435i.cc
+++ b/Examples/Monocular/mono_realsense_D435i.cc
@@ -27,12 +27,13 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -114,7 +115,7 @@ int main(int argc, char **argv) {
     sigaction(SIGINT, &sigIntHandler, NULL);
     b_continue_session = true;
 
-    double offset = 0; // ms
+    // double offset = 0; // UNUSED // ms
 
     rs2::context ctx;
     rs2::device_list devices = ctx.query_devices();
@@ -207,16 +208,18 @@ int main(int argc, char **argv) {
     std::cout << " Model = " << intrinsics_left.model << std::endl;
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     double timestamp;
     cv::Mat im;
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
-    while (!SLAM.isShutDown())
+#endif
+    while (viewer.isOpen())
     {
         std::vector<rs2_vector> vGyro;
         std::vector<double> vGyro_times;
@@ -228,7 +231,7 @@ int main(int argc, char **argv) {
             if(!image_ready)
                 cond_image_rec.wait(lk);
 
-            std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now();
+            // std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now(); // UNUSED
 
 
             if(count_im_buffer>1)
@@ -253,7 +256,7 @@ int main(int argc, char **argv) {
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
@@ -261,12 +264,13 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Stereo images are already rectified.
-        SLAM.TrackMonocular(im, timestamp);
+        auto pos = SLAM->TrackMonocular(im, timestamp);
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
+        viewer.update(pos);
     }
     cout << "System shutdown!\n";
 }

--- a/Examples/Monocular/mono_realsense_t265.cc
+++ b/Examples/Monocular/mono_realsense_t265.cc
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR, true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, true);
     float imageScale = SLAM.GetImageScale();
 
     cv::Mat imCV;

--- a/Examples/Monocular/mono_realsense_t265.cc
+++ b/Examples/Monocular/mono_realsense_t265.cc
@@ -25,11 +25,12 @@
 #include <ctime>
 #include <sstream>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -51,12 +52,12 @@ int main(int argc, char **argv)
     }
 
     string file_name;
-    bool bFileName = false;
+    // bool bFileName = false; // UNUSED
 
     if (argc == 4)
     {
         file_name = string(argv[argc-1]);
-        bFileName = true;
+        // bFileName = true; // UNUSED
     }
 
     struct sigaction sigIntHandler;
@@ -87,8 +88,9 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, true);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     cv::Mat imCV;
 
@@ -97,9 +99,10 @@ int main(int argc, char **argv)
     int width_img = intrinsics.width;
     int height_img = intrinsics.height;
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     while(b_continue_session)
     {
         //cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(3.0, cv::Size(8, 8));
@@ -124,7 +127,7 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -137,21 +140,21 @@ int main(int argc, char **argv)
 #endif
 
             // Pass the image to the SLAM system
-            SLAM.TrackMonocular(imCV, timestamp_ms);
+            auto pos = SLAM->TrackMonocular(imCV, timestamp_ms);
 
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
-
+            viewer.update(pos);
         }
     }
 
     pipe.stop();
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     return 0;
 }

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
     int nImages = vstrImageFilenames.size();
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR,true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR,true);
     float imageScale = SLAM.GetImageScale();
 
     // Vector for tracking time statistics

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -21,9 +21,10 @@
 #include<fstream>
 #include<chrono>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 
 using namespace std;
 
@@ -47,8 +48,9 @@ int main(int argc, char **argv)
     int nImages = vstrImageFilenames.size();
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR,true);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     // Vector for tracking time statistics
     vector<float> vTimesTrack;
@@ -58,9 +60,10 @@ int main(int argc, char **argv)
     cout << "Start processing sequence ..." << endl;
     cout << "Images in the sequence: " << nImages << endl << endl;
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     // Main loop
     cv::Mat im;
     for(int ni=0; ni<nImages; ni++)
@@ -87,20 +90,20 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
         std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
 
         // Pass the image to the SLAM system
-        SLAM.TrackMonocular(im,tframe);
+        auto pos = SLAM->TrackMonocular(im,tframe);
 
         std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
-
+        viewer.update(pos);
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
         double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -119,7 +122,7 @@ int main(int argc, char **argv)
     }
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Tracking time statistics
     sort(vTimesTrack.begin(),vTimesTrack.end());
@@ -133,7 +136,7 @@ int main(int argc, char **argv)
     cout << "mean tracking time: " << totaltime/nImages << endl;
 
     // Save camera trajectory
-    SLAM.SaveKeyFrameTrajectoryTUM("KeyFrameTrajectory.txt");
+    SLAM->SaveKeyFrameTrajectoryTUM("KeyFrameTrajectory.txt");
 
     return 0;
 }

--- a/Examples/Monocular/mono_tum_vi.cc
+++ b/Examples/Monocular/mono_tum_vi.cc
@@ -23,9 +23,10 @@
 #include<iomanip>
 #include <unistd.h>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
-#include"System.h"
+#include <System.h>
+#include <Viewer.h>
 #include "Converter.h"
 
 using namespace std;
@@ -89,12 +90,14 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR,false, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
-
+#endif
     int proccIm = 0;
     for (seq = 0; seq<num_seq; seq++)
     {
@@ -120,7 +123,7 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -140,13 +143,13 @@ int main(int argc, char **argv)
             std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
 
             // Pass the image to the SLAM system
-            SLAM.TrackMonocular(im,tframe); // TODO change to monocular_inertial
+            auto pos = SLAM->TrackMonocular(im,tframe); // TODO change to monocular_inertial
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
-
+            viewer.update(pos);
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
             double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -169,14 +172,14 @@ int main(int argc, char **argv)
         {
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
 
     }
 
     // cout << "ttrack_tot = " << ttrack_tot << std::endl;
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
 
     // Tracking time statistics
@@ -187,13 +190,13 @@ int main(int argc, char **argv)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     sort(vTimesTrack.begin(),vTimesTrack.end());

--- a/Examples/Monocular/mono_tum_vi.cc
+++ b/Examples/Monocular/mono_tum_vi.cc
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR,false, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::MONOCULAR,false, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;

--- a/Examples/RGB-D-Inertial/rgbd_inertial_realsense_D435i.cc
+++ b/Examples/RGB-D-Inertial/rgbd_inertial_realsense_D435i.cc
@@ -27,13 +27,14 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
 
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -318,8 +319,9 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_RGBD, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_RGBD, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     double timestamp;
     cv::Mat im, depth;
@@ -330,10 +332,12 @@ int main(int argc, char **argv) {
     v_accel_data_sync.clear();
     v_accel_timestamp_sync.clear();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
 
-    while (!SLAM.isShutDown())
+    while (viewer.isOpen())
     {
         std::vector<rs2_vector> vGyro;
         std::vector<double> vGyro_times;
@@ -345,7 +349,7 @@ int main(int argc, char **argv) {
             if(!image_ready)
                 cond_image_rec.wait(lk);
 
-            std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now();
+            // std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now(); // UNUSED
 
 
             fs = fsSLAM;
@@ -398,7 +402,7 @@ int main(int argc, char **argv) {
         depthCV.convertTo(depthCV_8U,CV_8U,0.01);
         cv::imshow("depth image", depthCV_8U);*/
 
-        for(int i=0; i<vGyro.size(); ++i)
+        for(size_t i=0; i<vGyro.size(); ++i)
         {
             ORB_SLAM3::IMU::Point lastPoint(vAccel[i].x, vAccel[i].y, vAccel[i].z,
                                             vGyro[i].x, vGyro[i].y, vGyro[i].z,
@@ -419,7 +423,7 @@ int main(int argc, char **argv) {
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
@@ -427,13 +431,15 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Pass the image to the SLAM system
-        SLAM.TrackRGBD(im, depth, timestamp, vImuMeas);
+        auto pos = SLAM->TrackRGBD(im, depth, timestamp, vImuMeas);
 
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
+
+        viewer.update(pos);
 
         // Clear the previous IMU measurements to load the new ones
         vImuMeas.clear();

--- a/Examples/RGB-D-Inertial/rgbd_inertial_realsense_D435i.cc
+++ b/Examples/RGB-D-Inertial/rgbd_inertial_realsense_D435i.cc
@@ -318,7 +318,7 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_RGBD, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_RGBD, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double timestamp;

--- a/Examples/RGB-D/rgbd_realsense_D435i.cc
+++ b/Examples/RGB-D/rgbd_realsense_D435i.cc
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::RGBD, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::RGBD, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double timestamp;

--- a/Examples/RGB-D/rgbd_realsense_D435i.cc
+++ b/Examples/RGB-D/rgbd_realsense_D435i.cc
@@ -27,13 +27,14 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
 
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -108,11 +109,11 @@ int main(int argc, char **argv) {
     }
 
     string file_name;
-    bool bFileName = false;
+    // bool bFileName = false; // UNUSED
 
     if (argc == 4) {
         file_name = string(argv[argc - 1]);
-        bFileName = true;
+        // bFileName = true; // UNUSED
     }
 
     struct sigaction sigIntHandler;
@@ -124,7 +125,7 @@ int main(int argc, char **argv) {
     sigaction(SIGINT, &sigIntHandler, NULL);
     b_continue_session = true;
 
-    double offset = 0; // ms
+    // double offset = 0; // UNUSED // ms
 
     rs2::context ctx;
     rs2::device_list devices = ctx.query_devices();
@@ -188,9 +189,9 @@ int main(int argc, char **argv) {
     vector<double> v_gyro_timestamp;
     vector<rs2_vector> v_gyro_data;
 
-    double prev_accel_timestamp = 0;
-    rs2_vector prev_accel_data;
-    double current_accel_timestamp = 0;
+    // double prev_accel_timestamp = 0; // UNUSED
+    // rs2_vector prev_accel_data; // UNUSED
+    // double current_accel_timestamp = 0;  // UNUSED
     rs2_vector current_accel_data;
     vector<double> v_accel_timestamp_sync;
     vector<rs2_vector> v_accel_data_sync;
@@ -306,24 +307,27 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::RGBD, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::RGBD, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     double timestamp;
     cv::Mat im, depth;
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
     rs2::frameset fs;
 
-    while (!SLAM.isShutDown())
+    while (viewer.isOpen())
     {
         {
             std::unique_lock<std::mutex> lk(imu_mutex);
             if(!image_ready)
                 cond_image_rec.wait(lk);
 
-            std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now();
+            // std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now(); // UNUSED
 
 
             fs = fsSLAM;
@@ -366,7 +370,7 @@ int main(int argc, char **argv) {
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
@@ -374,13 +378,14 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Pass the image to the SLAM system
-        SLAM.TrackRGBD(im, depth, timestamp); //, vImuMeas); depthCV
+        auto pos = SLAM->TrackRGBD(im, depth, timestamp); //, vImuMeas); depthCV
 
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
+        viewer.update(pos);
     }
     cout << "System shutdown!\n";
 }

--- a/Examples/RGB-D/rgbd_tum.cc
+++ b/Examples/RGB-D/rgbd_tum.cc
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
     }
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::RGBD,true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::RGBD,true);
     float imageScale = SLAM.GetImageScale();
 
     // Vector for tracking time statistics

--- a/Examples/Stereo-Inertial/stereo_inertial_euroc.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_euroc.cc
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_STEREO, false);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, false);
 
     cv::Mat imLeft, imRight;
     for (seq = 0; seq<num_seq; seq++)

--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
@@ -27,12 +27,13 @@
 
 #include <condition_variable>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 #include "librealsense2/rsutil.h"
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -317,8 +318,9 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     double timestamp;
     cv::Mat im, imRight;
@@ -329,10 +331,12 @@ int main(int argc, char **argv) {
     v_accel_data_sync.clear();
     v_accel_timestamp_sync.clear();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
 
-    while (!SLAM.isShutDown())
+    while (viewer.isOpen())
     {
         std::vector<rs2_vector> vGyro;
         std::vector<double> vGyro_times;
@@ -344,7 +348,7 @@ int main(int argc, char **argv) {
             if(!image_ready)
                 cond_image_rec.wait(lk);
 
-            std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now();
+            // std::chrono::steady_clock::time_point time_Start_Process = std::chrono::steady_clock::now(); // UNUSED
 
 
             if(count_im_buffer>1)
@@ -382,7 +386,7 @@ int main(int argc, char **argv) {
         }
 
 
-        for(int i=0; i<vGyro.size(); ++i)
+        for(size_t i=0; i<vGyro.size(); ++i)
         {
             ORB_SLAM3::IMU::Point lastPoint(vAccel[i].x, vAccel[i].y, vAccel[i].z,
                                   vGyro[i].x, vGyro[i].y, vGyro[i].z,
@@ -403,7 +407,7 @@ int main(int argc, char **argv) {
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
@@ -411,12 +415,13 @@ int main(int argc, char **argv) {
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Stereo images are already rectified.
-        SLAM.TrackStereo(im, imRight, timestamp, vImuMeas);
+        auto pos = SLAM->TrackStereo(im, imRight, timestamp, vImuMeas);
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
+        viewer.update(pos);
 
 
 

--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_D435i.cc
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
 
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_STEREO, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double timestamp;

--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_t265.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_t265.cc
@@ -25,11 +25,12 @@
 #include <ctime>
 #include <sstream>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 
 #include <System.h>
+#include <Viewer.h>
 #include <condition_variable>
 #include "ImuTypes.h"
 
@@ -59,15 +60,16 @@ int main(int argc, char **argv)
     }
 
     string file_name;
-    bool bFileName = false;
+    // bool bFileName = false; // UNUSED
 
     if (argc == 5) {
         file_name = string(argv[argc - 1]);
-        bFileName = true;
+        // bFileName = true; // UNUSED
     }
 
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     struct sigaction sigIntHandler;
 
@@ -133,7 +135,7 @@ int main(int argc, char **argv)
             imCV_right = cv::Mat(cv::Size(width_img, height_img), CV_8U, (void*)(color_frame_right.get_data()), cv::Mat::AUTO_STEP);
 
             timestamp_image = new_timestamp_image;
-            double test = fs.get_timestamp()*1e-3;
+            // double test = fs.get_timestamp()*1e-3; // UNUSED
 
             image_ready = true;
 
@@ -205,12 +207,14 @@ int main(int argc, char **argv)
     v_accel_data_sync.clear();
     v_accel_timestamp_sync.clear();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
 
     cv::Mat im_left, im_right;
 
-    while (!SLAM.isShutDown()){
+    while (viewer.isOpen()){
         std::vector<rs2_vector> vGyro;
         std::vector<double> vGyro_times;
         std::vector<rs2_vector> vAccel;
@@ -252,7 +256,7 @@ int main(int argc, char **argv)
     #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
     #endif
             }
 
@@ -273,7 +277,7 @@ int main(int argc, char **argv)
         }
 
 
-        for(int i=0; i<vGyro.size(); ++i){
+        for(size_t i=0; i<vGyro.size(); ++i){
             ORB_SLAM3::IMU::Point lastPoint(vAccel[i].x, vAccel[i].y, vAccel[i].z,
                                             vGyro[i].x, vGyro[i].y, vGyro[i].z,
                                             vGyro_times[i]);
@@ -289,18 +293,18 @@ int main(int argc, char **argv)
         std::chrono::steady_clock::time_point t_Start_Track = std::chrono::steady_clock::now();
 #endif
         // Pass the image to the SLAM system
-        SLAM.TrackStereo(im_left, im_right, timestamp, vImuMeas);
+        auto pos = SLAM->TrackStereo(im_left, im_right, timestamp, vImuMeas);
 #ifdef REGISTER_TIMES
         std::chrono::steady_clock::time_point t_End_Track = std::chrono::steady_clock::now();
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Track - t_Start_Track).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
-
+        viewer.update(pos);
         // Clear the previous IMU measurements to load the new ones
         vImuMeas.clear();
     }
 
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     return 0;
 }

--- a/Examples/Stereo-Inertial/stereo_inertial_realsense_t265.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_realsense_t265.cc
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
         bFileName = true;
     }
 
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_STEREO, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     struct sigaction sigIntHandler;

--- a/Examples/Stereo-Inertial/stereo_inertial_tum_vi.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_tum_vi.cc
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::IMU_STEREO, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;

--- a/Examples/Stereo-Inertial/stereo_inertial_tum_vi.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_tum_vi.cc
@@ -23,9 +23,10 @@
 #include <ctime>
 #include <sstream>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 #include "ImuTypes.h"
 
 using namespace std;
@@ -119,11 +120,14 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::IMU_STEREO, file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
 
     int proccIm = 0;
     for (seq = 0; seq<num_seq; seq++)
@@ -153,7 +157,7 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -196,13 +200,15 @@ int main(int argc, char **argv)
             std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
 
             // Pass the image to the SLAM system
-            SLAM.TrackStereo(imLeft,imRight,tframe,vImuMeas);
+            auto pos = SLAM->TrackStereo(imLeft,imRight,tframe,vImuMeas);
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
 
+            viewer.update(pos);
+
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
             double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -225,13 +231,13 @@ int main(int argc, char **argv)
         {
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
     }
 
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Tracking time statistics
 
@@ -245,13 +251,13 @@ int main(int argc, char **argv)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     sort(vTimesTrack.begin(),vTimesTrack.end());

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -22,9 +22,10 @@
 #include<iomanip>
 #include<chrono>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 
 using namespace std;
 
@@ -88,17 +89,20 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO, true);
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
 
     cv::Mat imLeft, imRight;
     for (seq = 0; seq<num_seq; seq++)
     {
 
         // Seq loop
+#ifdef REGISTER_TIMES
         double t_resize = 0;
         double t_rect = 0;
         double t_track = 0;
         int num_rect = 0;
+#endif
         int proccIm = 0;
         for(int ni=0; ni<nImages[seq]; ni++, proccIm++)
         {
@@ -125,9 +129,11 @@ int main(int argc, char **argv)
             std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
 
             // Pass the images to the SLAM system
-            SLAM.TrackStereo(imLeft,imRight,tframe, vector<ORB_SLAM3::IMU::Point>(), vstrImageLeft[seq][ni]);
+            auto pos = SLAM->TrackStereo(imLeft,imRight,tframe, vector<ORB_SLAM3::IMU::Point>(), vstrImageLeft[seq][ni]);
 
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
+
+            viewer.update(pos);
 
 #ifdef REGISTER_TIMES
             t_track = t_resize + t_rect + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
@@ -153,25 +159,25 @@ int main(int argc, char **argv)
         {
             cout << "Changing the dataset" << endl;
 
-            SLAM.ChangeDataset();
+            SLAM->ChangeDataset();
         }
 
     }
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Save camera trajectory
     if (bFileName)
     {
         const string kf_file =  "kf_" + string(argv[argc-1]) + ".txt";
         const string f_file =  "f_" + string(argv[argc-1]) + ".txt";
-        SLAM.SaveTrajectoryEuRoC(f_file);
-        SLAM.SaveKeyFrameTrajectoryEuRoC(kf_file);
+        SLAM->SaveTrajectoryEuRoC(f_file);
+        SLAM->SaveKeyFrameTrajectoryEuRoC(kf_file);
     }
     else
     {
-        SLAM.SaveTrajectoryEuRoC("CameraTrajectory.txt");
-        SLAM.SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
+        SLAM->SaveTrajectoryEuRoC("CameraTrajectory.txt");
+        SLAM->SaveKeyFrameTrajectoryEuRoC("KeyFrameTrajectory.txt");
     }
 
     return 0;

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::STEREO, true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO, true);
 
     cv::Mat imLeft, imRight;
     for (seq = 0; seq<num_seq; seq++)

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -22,9 +22,10 @@
 #include<iomanip>
 #include<chrono>
 
-#include<opencv2/core/core.hpp>
+#include<opencv2/opencv.hpp>
 
 #include<System.h>
+#include<Viewer.h>
 
 using namespace std;
 
@@ -48,8 +49,10 @@ int main(int argc, char **argv)
     const int nImages = vstrImageLeft.size();
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO,true);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+
+    float imageScale = SLAM->GetImageScale();
 
     // Vector for tracking time statistics
     vector<float> vTimesTrack;
@@ -59,8 +62,10 @@ int main(int argc, char **argv)
     cout << "Start processing sequence ..." << endl;
     cout << "Images in the sequence: " << nImages << endl << endl;   
 
+#ifdef REGISTER_TIMES
     double t_track = 0.f;
     double t_resize = 0.f;
+#endif
 
     // Main loop
     cv::Mat imLeft, imRight;
@@ -90,20 +95,22 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
             t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-            SLAM.InsertResizeTime(t_resize);
+            SLAM->InsertResizeTime(t_resize);
 #endif
         }
 
         std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
 
         // Pass the images to the SLAM system
-        SLAM.TrackStereo(imLeft,imRight,tframe);
+        auto pos = SLAM->TrackStereo(imLeft,imRight,tframe);
 
         std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
 
+        viewer.update(pos);
+
 #ifdef REGISTER_TIMES
         t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-        SLAM.InsertTrackTime(t_track);
+        SLAM->InsertTrackTime(t_track);
 #endif
 
         double ttrack= std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1).count();
@@ -122,7 +129,7 @@ int main(int argc, char **argv)
     }
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
     // Tracking time statistics
     sort(vTimesTrack.begin(),vTimesTrack.end());
@@ -136,7 +143,7 @@ int main(int argc, char **argv)
     cout << "mean tracking time: " << totaltime/nImages << endl;
 
     // Save camera trajectory
-    SLAM.SaveTrajectoryKITTI("CameraTrajectory.txt");
+    SLAM->SaveTrajectoryKITTI("CameraTrajectory.txt");
 
     return 0;
 }

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     const int nImages = vstrImageLeft.size();
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::STEREO,true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO,true);
     float imageScale = SLAM.GetImageScale();
 
     // Vector for tracking time statistics

--- a/Examples/Stereo/stereo_realsense_D435i.cc
+++ b/Examples/Stereo/stereo_realsense_D435i.cc
@@ -242,7 +242,7 @@ int main(int argc, char** argv) {
 
   // Create SLAM system. It initializes all system threads and gets ready to
   // process frames.
-  ORB_SLAM3::System SLAM(argv[1], argv[2], ORB_SLAM3::System::STEREO, true, 0,
+  ORB_SLAM3::System SLAM(argv[1], argv[2], ORB_SLAM3::CameraType::STEREO, true, 0,
                          file_name);
   float imageScale = SLAM.GetImageScale();
 

--- a/Examples/Stereo/stereo_realsense_t265.cc
+++ b/Examples/Stereo/stereo_realsense_t265.cc
@@ -25,11 +25,12 @@
 #include <ctime>
 #include <sstream>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include <librealsense2/rs.hpp>
 
 #include <System.h>
+#include <Viewer.h>
 
 using namespace std;
 
@@ -51,12 +52,12 @@ int main(int argc, char **argv)
     }
 
     string file_name;
-    bool bFileName = false;
+    // bool bFileName = false; // UNUSED
 
     if (argc == 4)
     {
         file_name = string(argv[argc-1]);
-        bFileName = true;
+        // bFileName = true; // UNUSED
     }
 
     struct sigaction sigIntHandler;
@@ -89,8 +90,9 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO, true, 0, file_name);
-    float imageScale = SLAM.GetImageScale();
+    ORB_SLAM3::System_ptr SLAM = std::make_shared<ORB_SLAM3::System>(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO, /*0, */file_name);
+    ORB_SLAM3::Viewer viewer(SLAM, argv[2]);
+    float imageScale = SLAM->GetImageScale();
 
     cv::Mat imLeft, imRight;
     vector<ORB_SLAM3::IMU::Point> vImuMeas;
@@ -105,8 +107,10 @@ int main(int argc, char **argv)
     int width_right = intrinsics_right.width;
     int height_right = intrinsics_right.height;
 
+#ifdef REGISTER_TIMES
     double t_resize = 0.f;
     double t_track = 0.f;
+#endif
 
     while (b_continue_session)
     {
@@ -135,7 +139,7 @@ int main(int argc, char **argv)
 #ifdef REGISTER_TIMES
                 std::chrono::steady_clock::time_point t_End_Resize = std::chrono::steady_clock::now();
                 t_resize = std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t_End_Resize - t_Start_Resize).count();
-                SLAM.InsertResizeTime(t_resize);
+                SLAM->InsertResizeTime(t_resize);
 #endif
             }
 
@@ -147,15 +151,15 @@ int main(int argc, char **argv)
 #endif
 
             // Pass the image to the SLAM system
-            SLAM.TrackStereo(imLeft, imRight, timestamp);
+            auto pos = SLAM->TrackStereo(imLeft, imRight, timestamp);
 
 #ifdef REGISTER_TIMES
             std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
 #endif
-
+            viewer.update(pos);
 #ifdef REGISTER_TIMES
             t_track = t_resize + std::chrono::duration_cast<std::chrono::duration<double,std::milli> >(t2 - t1).count();
-            SLAM.InsertTrackTime(t_track);
+            SLAM->InsertTrackTime(t_track);
 #endif
 
 
@@ -165,7 +169,7 @@ int main(int argc, char **argv)
     pipe.stop();
 
     // Stop all threads
-    SLAM.Shutdown();
+    // SLAM.Shutdown();
 
 
     return 0;

--- a/Examples/Stereo/stereo_realsense_t265.cc
+++ b/Examples/Stereo/stereo_realsense_t265.cc
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     cout << "IMU data in the sequence: " << nImu << endl << endl;*/
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::STEREO, true, 0, file_name);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO, true, 0, file_name);
     float imageScale = SLAM.GetImageScale();
 
     cv::Mat imLeft, imRight;

--- a/Examples/Stereo/stereo_tum_vi.cc
+++ b/Examples/Stereo/stereo_tum_vi.cc
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
     cout.precision(17);
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::STEREO,true);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::CameraType::STEREO,true);
     float imageScale = SLAM.GetImageScale();
 
     cout << endl << "-------" << endl;

--- a/build.sh
+++ b/build.sh
@@ -26,10 +26,12 @@ make -j$(nproc)
 
 cd ../../../
 
-echo "Uncompress vocabulary ..."
 
 cd Vocabulary
-tar -xf ORBvoc.txt.tar.gz
+if [ ! -f "ORBvoc.txt" ]; then
+    echo "Uncompress vocabulary ..."
+    tar -xf ORBvoc.txt.tar.gz
+fi
 cd ..
 
 echo "Configuring and building ORB_SLAM3 ..."

--- a/include/Atlas.h
+++ b/include/Atlas.h
@@ -19,8 +19,7 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ATLAS_H
-#define ATLAS_H
+#pragma once
 
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/vector.hpp>
@@ -35,7 +34,6 @@
 #include "Pinhole.h"
 
 namespace ORB_SLAM3 {
-class Viewer;
 class Map;
 class MapPoint;
 class KeyFrame;
@@ -80,8 +78,6 @@ class Atlas {
   void ChangeMap(Map* pMap);
 
   unsigned long int GetLastInitKFid();
-
-  void SetViewer(Viewer* pViewer);
 
   // Method for change components in the current map
   void AddKeyFrame(KeyFrame* pKF);
@@ -152,9 +148,6 @@ class Atlas {
 
   unsigned long int mnLastInitKFidMap;
 
-  Viewer* mpViewer;
-  bool mHasViewer;
-
   // Class references for the map reconstruction from the save file
   KeyFrameDatabase* mpKeyFrameDB;
   ORBVocabulary* mpORBVocabulary;
@@ -165,5 +158,3 @@ class Atlas {
 };  // class Atlas
 
 }  // namespace ORB_SLAM3
-
-#endif  // ATLAS_H

--- a/include/FrameDrawer.h
+++ b/include/FrameDrawer.h
@@ -30,6 +30,7 @@
 namespace ORB_SLAM3 {
 
 class MapPoint;
+class Viewer
 
 class FrameDrawer {
  public:
@@ -43,9 +44,10 @@ class FrameDrawer {
   cv::Mat DrawFrame(float imageScale = 1.f);
   cv::Mat DrawRightFrame(float imageScale = 1.f);
 
-  bool both;
+  friend Viewer;
 
  protected:
+  bool both;
   void DrawTextInfo(cv::Mat &im, int nState, cv::Mat &imText);
 
   // Info of the frame to be drawn

--- a/include/FrameDrawer.h
+++ b/include/FrameDrawer.h
@@ -19,14 +19,14 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FRAMEDRAWER_H
-#define FRAMEDRAWER_H
+#pragma once
 
 #include <mutex>
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>
 #include <unordered_set>
 
+#include "ImprovedTypes.hpp"
 #include "Atlas.h"
 #include "MapPoint.h"
 #include "Tracking.h"
@@ -34,15 +34,14 @@
 namespace ORB_SLAM3 {
 
 class Tracking;
-class Viewer;
 
 class FrameDrawer {
  public:
   
-  FrameDrawer(Atlas *pAtlas);
+  FrameDrawer(const Atlas_ptr &pAtlas);
 
   // Update info from the last processed frame.
-  void Update(Tracking *pTracker);
+  void Update(const Tracking_ptr &pTracker);
 
   // Draw last processed frame.
   cv::Mat DrawFrame(float imageScale = 1.f);
@@ -66,7 +65,7 @@ class FrameDrawer {
   std::vector<float> mvCurrentDepth;
   float mThDepth;
 
-  Atlas *mpAtlas;
+  Atlas_ptr mpAtlas;
 
   std::mutex mMutex;
   vector<pair<cv::Point2f, cv::Point2f> > mvTracks;
@@ -83,5 +82,3 @@ class FrameDrawer {
 };
 
 }  // namespace ORB_SLAM3
-
-#endif  // FRAMEDRAWER_H

--- a/include/FrameDrawer.h
+++ b/include/FrameDrawer.h
@@ -22,15 +22,14 @@
 #pragma once
 
 #include <mutex>
-#include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/opencv.hpp>
 #include <vector>
 #include "ImprovedTypes.hpp"
 
 namespace ORB_SLAM3 {
 
 class MapPoint;
-class Viewer
+class Viewer;
 
 class FrameDrawer {
  public:
@@ -67,16 +66,6 @@ class FrameDrawer {
 
   std::mutex mMutex;
   std::vector<std::pair<cv::Point2f, cv::Point2f>> mvTracks;
-
-  Frame mCurrentFrame;
-  std::vector<MapPoint *> mvpLocalMap;
-  std::vector<cv::KeyPoint> mvMatchedKeys;
-  std::vector<MapPoint *> mvpMatchedMPs;
-  std::vector<cv::KeyPoint> mvOutlierKeys;
-  std::vector<MapPoint *> mvpOutlierMPs;
-
-  umap<long unsigned int, cv::Point2f> mmProjectPoints;
-  umap<long unsigned int, cv::Point2f> mmMatchedInImage;
 };
 
 }  // namespace ORB_SLAM3

--- a/include/FrameDrawer.h
+++ b/include/FrameDrawer.h
@@ -24,16 +24,12 @@
 #include <mutex>
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>
-#include <unordered_set>
-
+#include <vector>
 #include "ImprovedTypes.hpp"
-#include "Atlas.h"
-#include "MapPoint.h"
-#include "Tracking.h"
 
 namespace ORB_SLAM3 {
 
-class Tracking;
+class MapPoint;
 
 class FrameDrawer {
  public:
@@ -55,12 +51,12 @@ class FrameDrawer {
   // Info of the frame to be drawn
   cv::Mat mIm, mImRight;
   int N;
-  vector<cv::KeyPoint> mvCurrentKeys, mvCurrentKeysRight;
-  vector<bool> mvbMap, mvbVO;
+  std::vector<cv::KeyPoint> mvCurrentKeys, mvCurrentKeysRight;
+  std::vector<bool> mvbMap, mvbVO;
   bool mbOnlyTracking;
   int mnTracked, mnTrackedVO;
-  vector<cv::KeyPoint> mvIniKeys;
-  vector<int> mvIniMatches;
+  std::vector<cv::KeyPoint> mvIniKeys;
+  std::vector<int> mvIniMatches;
   int mState;
   std::vector<float> mvCurrentDepth;
   float mThDepth;
@@ -68,17 +64,17 @@ class FrameDrawer {
   Atlas_ptr mpAtlas;
 
   std::mutex mMutex;
-  vector<pair<cv::Point2f, cv::Point2f> > mvTracks;
+  std::vector<std::pair<cv::Point2f, cv::Point2f>> mvTracks;
 
   Frame mCurrentFrame;
-  vector<MapPoint *> mvpLocalMap;
-  vector<cv::KeyPoint> mvMatchedKeys;
-  vector<MapPoint *> mvpMatchedMPs;
-  vector<cv::KeyPoint> mvOutlierKeys;
-  vector<MapPoint *> mvpOutlierMPs;
+  std::vector<MapPoint *> mvpLocalMap;
+  std::vector<cv::KeyPoint> mvMatchedKeys;
+  std::vector<MapPoint *> mvpMatchedMPs;
+  std::vector<cv::KeyPoint> mvOutlierKeys;
+  std::vector<MapPoint *> mvpOutlierMPs;
 
-  map<long unsigned int, cv::Point2f> mmProjectPoints;
-  map<long unsigned int, cv::Point2f> mmMatchedInImage;
+  umap<long unsigned int, cv::Point2f> mmProjectPoints;
+  umap<long unsigned int, cv::Point2f> mmMatchedInImage;
 };
 
 }  // namespace ORB_SLAM3

--- a/include/ImprovedTypes.hpp
+++ b/include/ImprovedTypes.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <unordered_map>
+
+namespace ORB_SLAM3{
+
+class System;
+class Atlas;
+class Tracking;
+typedef std::shared_ptr<System> System_ptr;
+typedef std::weak_ptr<System> System_wptr;
+typedef std::shared_ptr<Atlas> Atlas_ptr;
+typedef std::weak_ptr<Atlas> Atlas_wptr;
+typedef std::shared_ptr<Tracking> Tracking_ptr;
+typedef std::weak_ptr<Tracking> Tracking_wptr;
+
+typedef std::pair<int, int> IntPair;
+template<typename KEY, typename VALUE> using umap = std::unordered_map<KEY,VALUE>;
+
+}

--- a/include/ImprovedTypes.hpp
+++ b/include/ImprovedTypes.hpp
@@ -19,4 +19,18 @@ typedef std::weak_ptr<Tracking> Tracking_wptr;
 typedef std::pair<int, int> IntPair;
 template<typename KEY, typename VALUE> using umap = std::unordered_map<KEY,VALUE>;
 
+
+
+  namespace Tracker{
+    // Tracking states
+    enum eTrackingState {
+        SYSTEM_NOT_READY = -1,
+        NO_IMAGES_YET = 0,
+        NOT_INITIALIZED = 1,
+        OK = 2,
+        RECENTLY_LOST = 3,
+        LOST = 4,
+        OK_KLT = 5
+    };
+  }
 }

--- a/include/ImprovedTypes.hpp
+++ b/include/ImprovedTypes.hpp
@@ -33,4 +33,16 @@ template<typename KEY, typename VALUE> using umap = std::unordered_map<KEY,VALUE
         OK_KLT = 5
     };
   }
+
+  namespace CameraType{
+    // Input sensor
+    enum eSensor{
+        MONOCULAR=0,
+        STEREO=1,
+        RGBD=2,
+        IMU_MONOCULAR=3,
+        IMU_STEREO=4,
+        IMU_RGBD=5,
+    };
+  }
 }

--- a/include/LocalMapping.h
+++ b/include/LocalMapping.h
@@ -19,8 +19,7 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LOCALMAPPING_H
-#define LOCALMAPPING_H
+#pragma once
 
 #include <mutex>
 
@@ -196,4 +195,3 @@ class LocalMapping {
 
 }  // namespace ORB_SLAM3
 
-#endif  // LOCALMAPPING_H

--- a/include/LocalMapping.h
+++ b/include/LocalMapping.h
@@ -23,6 +23,7 @@
 
 #include <mutex>
 
+#include "ImprovedTypes.hpp"
 #include "Atlas.h"
 #include "KeyFrame.h"
 #include "KeyFrameDatabase.h"
@@ -40,7 +41,7 @@ class Atlas;
 class LocalMapping {
  public:
   
-  LocalMapping(System* pSys, Atlas* pAtlas, const float bMonocular,
+  LocalMapping(System* pSys, const Atlas_ptr &pAtlas, const float bMonocular,
                bool bInertial, const string& _strSeqName = std::string());
 
   void SetLoopCloser(LoopClosing* pLoopCloser);
@@ -152,7 +153,7 @@ class LocalMapping {
   bool mbFinished;
   std::mutex mMutexFinish;
 
-  Atlas* mpAtlas;
+  Atlas_ptr mpAtlas;
 
   LoopClosing* mpLoopCloser;
   Tracking* mpTracker;

--- a/include/LocalMapping.h
+++ b/include/LocalMapping.h
@@ -97,7 +97,6 @@ class LocalMapping {
   int mnMatchesInliers;
 
   // For debugging (erase in normal mode)
-  int mInitFr;
   int mIdxIteration;
   string strSequence;
 

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -82,8 +82,6 @@ public:
 
     bool isFinished();
 
-    Viewer* mpViewer;
-
 #ifdef REGISTER_TIMES
 
     vector<double> vdDataQuery_ms;

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -17,9 +17,9 @@
 */
 
 
-#ifndef LOOPCLOSING_H
-#define LOOPCLOSING_H
+#pragma once
 
+#include "ImprovedTypes.hpp"
 #include "KeyFrame.h"
 #include "LocalMapping.h"
 #include "Atlas.h"
@@ -52,7 +52,7 @@ public:
 
 public:
 
-    LoopClosing(Atlas* pAtlas, KeyFrameDatabase* pDB, ORBVocabulary* pVoc,const bool bFixScale, const bool bActiveLC);
+    LoopClosing(const Atlas_ptr &pAtlas, KeyFrameDatabase* pDB, ORBVocabulary* pVoc,const bool bFixScale, const bool bActiveLC);
 
     void SetTracker(Tracking* pTracker);
 
@@ -154,7 +154,7 @@ protected:
     bool mbFinished;
     std::mutex mMutexFinish;
 
-    Atlas* mpAtlas;
+    Atlas_ptr mpAtlas;
     Tracking* mpTracker;
 
     KeyFrameDatabase* mpKeyFrameDB;
@@ -243,4 +243,3 @@ protected:
 
 } //namespace ORB_SLAM
 
-#endif // LOOPCLOSING_H

--- a/include/MapDrawer.h
+++ b/include/MapDrawer.h
@@ -17,9 +17,9 @@
 */
 
 
-#ifndef MAPDRAWER_H
-#define MAPDRAWER_H
+#pragma once
 
+#include "ImprovedTypes.hpp"
 #include"Atlas.h"
 #include"MapPoint.h"
 #include"KeyFrame.h"
@@ -35,13 +35,12 @@ class Settings;
 
 class MapDrawer
 {
+    void newParameterLoader(const Settings& settings);
+    Atlas_ptr mpAtlas;
+
 public:
-    
-    MapDrawer(Atlas* pAtlas, const string &strSettingPath, Settings* settings);
-
-    void newParameterLoader(Settings* settings);
-
-    Atlas* mpAtlas;
+    MapDrawer(const Atlas_ptr &pAtlas, const std::string &strSettingPath);
+    MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings);
 
     void DrawMapPoints();
     void DrawKeyFrames(const bool bDrawKF, const bool bDrawGraph, const bool bDrawInertialGraph, const bool bDrawOptLba);
@@ -76,4 +75,3 @@ private:
 
 } //namespace ORB_SLAM
 
-#endif // MAPDRAWER_H

--- a/include/MapDrawer.h
+++ b/include/MapDrawer.h
@@ -20,9 +20,6 @@
 #pragma once
 
 #include "ImprovedTypes.hpp"
-#include"Atlas.h"
-#include"MapPoint.h"
-#include"KeyFrame.h"
 #include "Settings.h"
 #include<pangolin/pangolin.h>
 
@@ -32,25 +29,13 @@ namespace ORB_SLAM3
 {
 
 class Settings;
+class KeyFrame;
 
 class MapDrawer
 {
     void newParameterLoader(const Settings& settings);
     Atlas_ptr mpAtlas;
-
-public:
-    MapDrawer(const Atlas_ptr &pAtlas, const std::string &strSettingPath);
-    MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings);
-
-    void DrawMapPoints();
-    void DrawKeyFrames(const bool bDrawKF, const bool bDrawGraph, const bool bDrawInertialGraph, const bool bDrawOptLba);
-    void DrawCurrentCamera(pangolin::OpenGlMatrix &Twc);
-    void SetCurrentCameraPose(const Sophus::SE3f &Tcw);
-    void SetReferenceKeyFrame(KeyFrame *pKF);
-    void GetCurrentOpenGLCameraMatrix(pangolin::OpenGlMatrix &M, pangolin::OpenGlMatrix &MOw);
-
-private:
-
+    
     bool ParseViewerParamFile(cv::FileStorage &fSettings);
 
     float mKeyFrameSize;
@@ -70,6 +55,17 @@ private:
                                 {0.6f, 0.0f, 1.0f},
                                 {1.0f, 1.0f, 0.0f},
                                 {0.0f, 1.0f, 1.0f}};
+
+public:
+    MapDrawer(const Atlas_ptr &pAtlas, const std::string &strSettingPath);
+    MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings);
+
+    void DrawMapPoints();
+    void DrawKeyFrames(const bool bDrawKF, const bool bDrawGraph, const bool bDrawInertialGraph, const bool bDrawOptLba);
+    void DrawCurrentCamera(pangolin::OpenGlMatrix &Twc);
+    void SetCurrentCameraPose(const Sophus::SE3f &Tcw);
+    void SetReferenceKeyFrame(KeyFrame *pKF);
+    void GetCurrentOpenGLCameraMatrix(pangolin::OpenGlMatrix &M, pangolin::OpenGlMatrix &MOw);
 
 };
 

--- a/include/Settings.h
+++ b/include/Settings.h
@@ -65,7 +65,7 @@ class Settings {
   /*
    * Getter methods
    */
-  CameraType cameraType() { return cameraType_; }
+  CameraType cameraType() const { return cameraType_; }
   GeometricCamera* camera1() { return calibration1_; }
   GeometricCamera* camera2() { return calibration2_; }
   cv::Mat camera1DistortionCoef() {
@@ -74,59 +74,59 @@ class Settings {
   }
   cv::Mat camera2DistortionCoef() {
     return cv::Mat(vPinHoleDistorsion2_.size(), 1, CV_32F,
-                   vPinHoleDistorsion1_.data());
+                   vPinHoleDistorsion2_.data());
   }
 
-  Sophus::SE3f Tlr() { return Tlr_; }
-  float bf() { return bf_; }
-  float b() { return b_; }
-  float thDepth() { return thDepth_; }
+  const Sophus::SE3f &Tlr() const { return Tlr_; }
+  float bf() const { return bf_; }
+  float b() const { return b_; }
+  float thDepth() const { return thDepth_; }
 
-  bool needToUndistort() { return bNeedToUndistort_; }
+  bool needToUndistort() const { return bNeedToUndistort_; }
 
-  cv::Size newImSize() { return newImSize_; }
-  float fps() { return fps_; }
-  bool rgb() { return bRGB_; }
-  bool needToResize() { return bNeedToResize1_; }
-  bool needToRectify() { return bNeedToRectify_; }
+  const cv::Size &newImSize() const { return newImSize_; }
+  float fps() const { return fps_; }
+  bool rgb() const { return bRGB_; }
+  bool needToResize() const { return bNeedToResize1_; }
+  bool needToRectify() const { return bNeedToRectify_; }
 
-  float noiseGyro() { return noiseGyro_; }
-  float noiseAcc() { return noiseAcc_; }
-  float gyroWalk() { return gyroWalk_; }
-  float accWalk() { return accWalk_; }
-  float imuFrequency() { return imuFrequency_; }
-  Sophus::SE3f Tbc() { return Tbc_; }
-  bool insertKFsWhenLost() { return insertKFsWhenLost_; }
+  float noiseGyro() const { return noiseGyro_; }
+  float noiseAcc() const { return noiseAcc_; }
+  float gyroWalk() const { return gyroWalk_; }
+  float accWalk() const { return accWalk_; }
+  float imuFrequency() const { return imuFrequency_; }
+  const Sophus::SE3f &Tbc() const { return Tbc_; }
+  bool insertKFsWhenLost() const { return insertKFsWhenLost_; }
 
-  float depthMapFactor() { return depthMapFactor_; }
+  float depthMapFactor() const { return depthMapFactor_; }
 
-  int nFeatures() { return nFeatures_; }
-  int nLevels() { return nLevels_; }
-  float initThFAST() { return initThFAST_; }
-  float minThFAST() { return minThFAST_; }
-  float scaleFactor() { return scaleFactor_; }
+  int nFeatures() const { return nFeatures_; }
+  int nLevels() const { return nLevels_; }
+  float initThFAST() const { return initThFAST_; }
+  float minThFAST() const { return minThFAST_; }
+  float scaleFactor() const { return scaleFactor_; }
 
-  float keyFrameSize() { return keyFrameSize_; }
-  float keyFrameLineWidth() { return keyFrameLineWidth_; }
-  float graphLineWidth() { return graphLineWidth_; }
-  float pointSize() { return pointSize_; }
-  float cameraSize() { return cameraSize_; }
-  float cameraLineWidth() { return cameraLineWidth_; }
-  float viewPointX() { return viewPointX_; }
-  float viewPointY() { return viewPointY_; }
-  float viewPointZ() { return viewPointZ_; }
-  float viewPointF() { return viewPointF_; }
-  float imageViewerScale() { return imageViewerScale_; }
+  float keyFrameSize() const { return keyFrameSize_; }
+  float keyFrameLineWidth() const { return keyFrameLineWidth_; }
+  float graphLineWidth() const { return graphLineWidth_; }
+  float pointSize() const { return pointSize_; }
+  float cameraSize() const { return cameraSize_; }
+  float cameraLineWidth() const { return cameraLineWidth_; }
+  float viewPointX() const { return viewPointX_; }
+  float viewPointY() const { return viewPointY_; }
+  float viewPointZ() const { return viewPointZ_; }
+  float viewPointF() const { return viewPointF_; }
+  float imageViewerScale() const { return imageViewerScale_; }
 
-  std::string atlasLoadFile() { return sLoadFrom_; }
-  std::string atlasSaveFile() { return sSaveto_; }
+  const std::string &atlasLoadFile() const { return sLoadFrom_; }
+  const std::string &atlasSaveFile() const { return sSaveto_; }
 
-  float thFarPoints() { return thFarPoints_; }
+  float thFarPoints() const { return thFarPoints_; }
 
-  cv::Mat M1l() { return M1l_; }
-  cv::Mat M2l() { return M2l_; }
-  cv::Mat M1r() { return M1r_; }
-  cv::Mat M2r() { return M2r_; }
+  const cv::Mat &M1l() const { return M1l_; }
+  const cv::Mat &M2l() const { return M2l_; }
+  const cv::Mat &M1r() const { return M1r_; }
+  const cv::Mat &M2r() const { return M2r_; }
 
  private:
   template <typename T>

--- a/include/System.h
+++ b/include/System.h
@@ -102,7 +102,7 @@ public:
 public:
     
     // Initialize the SLAM system. It launches the Local Mapping, Loop Closing and Viewer threads.
-    System(const string &strVocFile, const string &strSettingsFile, const eSensor sensor, const bool bUseViewer = true, const int initFr = 0, const string &strSequence = std::string());
+    System(const string &strVocFile, const string &strSettingsFile, const eSensor sensor, const bool bUseViewer = true, const string &strSequence = std::string());
 
     // Proccess the given stereo frame. Images must be synchronized and rectified.
     // Input images: RGB (CV_8UC3) or grayscale (CV_8U). RGB is converted to grayscale.

--- a/include/System.h
+++ b/include/System.h
@@ -89,7 +89,7 @@ public:
 public:
     
     // Initialize the SLAM system. It launches the Local Mapping, Loop Closing and Viewer threads.
-    System(const string &strVocFile, const string &strSettingsFile, const eSensor sensor, const string &strSequence = std::string());
+    System(const string &strVocFile, const string &strSettingsFile, const CameraType::eSensor sensor, const string &strSequence = std::string());
 
     // Proccess the given stereo frame. Images must be synchronized and rectified.
     // Input images: RGB (CV_8UC3) or grayscale (CV_8U). RGB is converted to grayscale.

--- a/include/System.h
+++ b/include/System.h
@@ -102,7 +102,7 @@ public:
 public:
     
     // Initialize the SLAM system. It launches the Local Mapping, Loop Closing and Viewer threads.
-    System(const string &strVocFile, const string &strSettingsFile, const eSensor sensor, const bool bUseViewer = true, const string &strSequence = std::string());
+    System(const string &strVocFile, const string &strSettingsFile, const eSensor sensor, const string &strSequence = std::string());
 
     // Proccess the given stereo frame. Images must be synchronized and rectified.
     // Input images: RGB (CV_8UC3) or grayscale (CV_8U). RGB is converted to grayscale.
@@ -137,8 +137,7 @@ public:
     // All threads will be requested to finish.
     // It waits until all threads have finished.
     // This function must be called before saving the trajectory.
-    void Shutdown();
-    bool isShutDown();
+    virtual ~System();
 
     // Save camera trajectory in the TUM RGB-D dataset format.
     // Only for stereo and RGB-D. This method does not work for monocular.
@@ -192,6 +191,7 @@ public:
     void InsertTrackTime(double& time);
 #endif
 
+    friend Viewer;
 private:
 
     void SaveAtlas(int type);
@@ -224,17 +224,17 @@ private:
     // a pose graph optimization and full bundle adjustment (in a new thread) afterwards.
     LoopClosing* mpLoopCloser;
 
-    // The viewer draws the map and the current camera pose. It uses Pangolin.
-    Viewer* mpViewer;
+    // // The viewer draws the map and the current camera pose. It uses Pangolin.
+    // Viewer* mpViewer;
 
-    FrameDrawer* mpFrameDrawer;
-    MapDrawer* mpMapDrawer;
+    // FrameDrawer* mpFrameDrawer;
+    // MapDrawer* mpMapDrawer;
 
     // System threads: Local Mapping, Loop Closing, Viewer.
     // The Tracking thread "lives" in the main execution thread that creates the System object.
     std::thread* mptLocalMapping;
     std::thread* mptLoopClosing;
-    std::thread* mptViewer;
+    // std::thread* mptViewer;
 
     // Reset flag
     std::mutex mMutexReset;

--- a/include/System.h
+++ b/include/System.h
@@ -36,7 +36,6 @@
 #include "LoopClosing.h"
 #include "KeyFrameDatabase.h"
 #include "ORBVocabulary.h"
-#include "Viewer.h"
 #include "ImuTypes.h"
 #include "Settings.h"
 
@@ -224,17 +223,10 @@ private:
     // a pose graph optimization and full bundle adjustment (in a new thread) afterwards.
     LoopClosing* mpLoopCloser;
 
-    // // The viewer draws the map and the current camera pose. It uses Pangolin.
-    // Viewer* mpViewer;
-
-    // FrameDrawer* mpFrameDrawer;
-    // MapDrawer* mpMapDrawer;
-
     // System threads: Local Mapping, Loop Closing, Viewer.
     // The Tracking thread "lives" in the main execution thread that creates the System object.
     std::thread* mptLocalMapping;
     std::thread* mptLoopClosing;
-    // std::thread* mptViewer;
 
     // Reset flag
     std::mutex mMutexReset;

--- a/include/System.h
+++ b/include/System.h
@@ -196,7 +196,7 @@ private:
 
     // Map structure that stores the pointers to all KeyFrames and MapPoints.
     //Map* mpMap;
-    Atlas mpAtlas;
+    Atlas_ptr mpAtlas;
 
     // Tracker. It receives a frame and computes the associated camera pose.
     // It also decides when to insert a new keyframe, create some new MapPoints and

--- a/include/System.h
+++ b/include/System.h
@@ -17,8 +17,7 @@
 */
 
 
-#ifndef SYSTEM_H
-#define SYSTEM_H
+#pragma once
 
 
 #include <unistd.h>
@@ -226,9 +225,6 @@ private:
     bool mbActivateLocalizationMode;
     bool mbDeactivateLocalizationMode;
 
-    // Shutdown flag
-    bool mbShutDown;
-
     // Tracking state
     int mTrackingState;
     std::vector<MapPoint*> mTrackedMapPoints;
@@ -245,5 +241,3 @@ private:
 };
 
 }// namespace ORB_SLAM
-
-#endif // SYSTEM_H

--- a/include/System.h
+++ b/include/System.h
@@ -22,15 +22,14 @@
 
 
 #include <unistd.h>
-#include<stdio.h>
-#include<stdlib.h>
-#include<string>
-#include<thread>
-#include<opencv2/core/core.hpp>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <thread>
+#include <opencv2/core/core.hpp>
 
+#include "ImprovedTypes.hpp"
 #include "Tracking.h"
-#include "FrameDrawer.h"
-#include "MapDrawer.h"
 #include "Atlas.h"
 #include "LocalMapping.h"
 #include "LoopClosing.h"
@@ -71,8 +70,6 @@ public:
 };
 
 class Viewer;
-class FrameDrawer;
-class MapDrawer;
 class Atlas;
 class Tracking;
 class LocalMapping;
@@ -82,15 +79,6 @@ class Settings;
 class System
 {
 public:
-    // Input sensor
-    enum eSensor{
-        MONOCULAR=0,
-        STEREO=1,
-        RGBD=2,
-        IMU_MONOCULAR=3,
-        IMU_STEREO=4,
-        IMU_RGBD=5,
-    };
 
     // File type
     enum FileType{
@@ -199,7 +187,7 @@ private:
     string CalculateCheckSum(string filename, int type);
 
     // Input sensor
-    eSensor mSensor;
+    CameraType::eSensor mSensor;
 
     // ORB vocabulary used for place recognition and feature matching.
     ORBVocabulary* mpVocabulary;

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -29,23 +29,18 @@
 
 #include "Atlas.h"
 #include "Frame.h"
-#include "FrameDrawer.h"
 #include "GeometricCamera.h"
 #include "ImuTypes.h"
 #include "KeyFrameDatabase.h"
 #include "LocalMapping.h"
 #include "LoopClosing.h"
-#include "MapDrawer.h"
 #include "ORBVocabulary.h"
 #include "ORBextractor.h"
 #include "Settings.h"
 #include "System.h"
-#include "Viewer.h"
 
 namespace ORB_SLAM3 {
 
-class Viewer;
-class FrameDrawer;
 class Atlas;
 class LocalMapping;
 class LoopClosing;
@@ -55,8 +50,8 @@ class Settings;
 class Tracking {
  public:
   
-  Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer,
-           MapDrawer* pMapDrawer, Atlas* pAtlas, KeyFrameDatabase* pKFDB,
+  Tracking(System* pSys, ORBVocabulary* pVoc,
+           Atlas* pAtlas, KeyFrameDatabase* pKFDB,
            const string& strSettingPath, const int sensor, Settings* settings,
            const string& _nameSeq = std::string());
 
@@ -81,7 +76,6 @@ class Tracking {
 
   void SetLocalMapper(LocalMapping* pLocalMapper);
   void SetLoopClosing(LoopClosing* pLoopClosing);
-  void SetViewer(Viewer* pViewer);
   void SetStepByStep(bool bSet);
   bool GetStepByStep();
 
@@ -285,9 +279,9 @@ class Tracking {
   System* mpSystem;
 
   // Drawers
-  Viewer* mpViewer;
-  FrameDrawer* mpFrameDrawer;
-  MapDrawer* mpMapDrawer;
+  // Viewer* mpViewer;
+  // FrameDrawer* mpFrameDrawer;
+  // MapDrawer* mpMapDrawer;
   bool bStepByStep;
 
   // Atlas

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -266,12 +266,6 @@ class Tracking {
   // System
   System* mpSystem;
 
-  // Drawers
-  // Viewer* mpViewer;
-  // FrameDrawer* mpFrameDrawer;
-  // MapDrawer* mpMapDrawer;
-  // bool bStepByStep;
-
   // Atlas
   Atlas* mpAtlas;
 

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -115,8 +115,8 @@ class Tracking {
 
  public:
 
-  eTrackingState mState;
-  eTrackingState mLastProcessedState;
+  Tracker::eTrackingState mState;
+  Tracker::eTrackingState mLastProcessedState;
 
   // Input sensor
   int mSensor;

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -51,7 +51,7 @@ class Tracking {
  public:
   
   Tracking(System* pSys, ORBVocabulary* pVoc,
-           Atlas* pAtlas, KeyFrameDatabase* pKFDB,
+           const Atlas_ptr &pAtlas, KeyFrameDatabase* pKFDB,
            const string& strSettingPath, const int sensor, Settings* settings,
            const string& _nameSeq = std::string());
 
@@ -267,7 +267,7 @@ class Tracking {
   System* mpSystem;
 
   // Atlas
-  Atlas* mpAtlas;
+  Atlas_ptr mpAtlas;
 
   // Calibration matrix
   cv::Mat mK;

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -19,8 +19,7 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TRACKING_H
-#define TRACKING_H
+#pragma once
 
 #include <mutex>
 #include <opencv2/core/core.hpp>
@@ -77,8 +76,6 @@ class Tracking {
 
   void SetLocalMapper(LocalMapping* pLocalMapper);
   void SetLoopClosing(LoopClosing* pLoopClosing);
-  void SetStepByStep(bool bSet);
-  bool GetStepByStep();
 
   // Load new settings
   // The focal lenght should be similar or scale prediction will fail when
@@ -273,7 +270,7 @@ class Tracking {
   // Viewer* mpViewer;
   // FrameDrawer* mpFrameDrawer;
   // MapDrawer* mpMapDrawer;
-  bool bStepByStep;
+  // bool bStepByStep;
 
   // Atlas
   Atlas* mpAtlas;
@@ -366,4 +363,3 @@ class Tracking {
 
 }  // namespace ORB_SLAM3
 
-#endif  // TRACKING_H

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -38,6 +38,7 @@
 #include "ORBextractor.h"
 #include "Settings.h"
 #include "System.h"
+#include "ImprovedTypes.hpp"
 
 namespace ORB_SLAM3 {
 
@@ -116,16 +117,6 @@ class Tracking {
 #endif
 
  public:
-  // Tracking states
-  enum eTrackingState {
-    SYSTEM_NOT_READY = -1,
-    NO_IMAGES_YET = 0,
-    NOT_INITIALIZED = 1,
-    OK = 2,
-    RECENTLY_LOST = 3,
-    LOST = 4,
-    OK_KLT = 5
-  };
 
   eTrackingState mState;
   eTrackingState mLastProcessedState;

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -44,7 +44,7 @@ class Viewer {
 
   virtual ~Viewer();
 
-  void update();
+  void update(const Sophus::SE3f &pose);
 
   void close();
   bool isClosed() const;

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -28,14 +28,8 @@
 #include "FrameDrawer.h"
 #include "MapDrawer.h"
 #include "Settings.h"
-#include "System.h"
 
 namespace ORB_SLAM3 {
-
-class FrameDrawer;
-class MapDrawer;
-class System;
-class Settings;
 
 class Viewer {
   void newParameterLoader(const Settings& settings);

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -19,11 +19,12 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef VIEWER_H
-#define VIEWER_H
+#pragma once
 
 #include <mutex>
+#include <memory>
 
+#include "ImprovedTypes.hpp"
 #include "FrameDrawer.h"
 #include "MapDrawer.h"
 #include "Settings.h"
@@ -39,17 +40,20 @@ class System;
 class Settings;
 
 class Viewer {
- public:
-  
-  Viewer(System* pSystem, FrameDrawer* pFrameDrawer, MapDrawer* pMapDrawer,
-         Tracking* pTracking, const string& strSettingPath, Settings* settings);
-
-  void newParameterLoader(Settings* settings);
-
+  void newParameterLoader(const Settings& settings);
   // Main thread function. Draw points, keyframes, the current camera pose and
   // the last processed frame. Drawing is refreshed according to the camera fps.
   // We use Pangolin.
   void Run();
+ public:
+
+  Viewer(const System_ptr &pSystem, const std::string &strSettingPath);
+  Viewer(const System_ptr &pSystem, const Settings &settings);
+
+  virtual ~Viewer();
+
+  void update();
+
 
   void RequestFinish();
 
@@ -72,10 +76,11 @@ class Viewer {
 
   bool Stop();
 
-  System* mpSystem;
-  FrameDrawer* mpFrameDrawer;
-  MapDrawer* mpMapDrawer;
-  Tracking* mpTracker;
+  System_ptr mpSystem;
+  FrameDrawer mpFrameDrawer;
+  MapDrawer mpMapDrawer;
+  Tracking_ptr mpTracker;
+  std::thread mptViewer;
 
   // 1/fps in ms
   double mT;
@@ -98,5 +103,3 @@ class Viewer {
 };
 
 }  // namespace ORB_SLAM3
-
-#endif  // VIEWER_H

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -56,9 +56,9 @@ class Viewer {
   bool isClosed() const;
   bool isOpen() const;
 
-  bool both;
 
  private:
+  void setBoth(const bool b);
   bool ParseViewerParamFile(cv::FileStorage& fSettings);
 
   bool Stop();
@@ -68,6 +68,7 @@ class Viewer {
   MapDrawer mpMapDrawer;
   Tracking_ptr mpTracker;
   std::thread mptViewer;
+  bool both;
 
   // 1/fps in ms
   double mT;

--- a/include/Viewer.h
+++ b/include/Viewer.h
@@ -29,11 +29,9 @@
 #include "MapDrawer.h"
 #include "Settings.h"
 #include "System.h"
-#include "Tracking.h"
 
 namespace ORB_SLAM3 {
 
-class Tracking;
 class FrameDrawer;
 class MapDrawer;
 class System;
@@ -54,20 +52,9 @@ class Viewer {
 
   void update();
 
-
-  void RequestFinish();
-
-  void RequestStop();
-
-  bool isFinished();
-
-  bool isStopped();
-
-  bool isStepByStep();
-
-  void Release();
-
-  // void SetTrackingPause();
+  void close();
+  bool isClosed() const;
+  bool isOpen() const;
 
   bool both;
 
@@ -89,17 +76,7 @@ class Viewer {
 
   float mViewpointX, mViewpointY, mViewpointZ, mViewpointF;
 
-  bool CheckFinish();
-  void SetFinish();
-  bool mbFinishRequested;
-  bool mbFinished;
-  std::mutex mMutexFinish;
-
-  bool mbStopped;
-  bool mbStopRequested;
-  std::mutex mMutexStop;
-
-  bool mbStopTrack;
+  bool mbClosed;
 };
 
 }  // namespace ORB_SLAM3

--- a/src/Atlas.cc
+++ b/src/Atlas.cc
@@ -24,13 +24,12 @@
 #include "GeometricCamera.h"
 #include "KannalaBrandt8.h"
 #include "Pinhole.h"
-#include "Viewer.h"
 
 namespace ORB_SLAM3 {
 
 Atlas::Atlas() { mpCurrentMap = static_cast<Map*>(NULL); }
 
-Atlas::Atlas(int initKFid) : mnLastInitKFidMap(initKFid), mHasViewer(false) {
+Atlas::Atlas(int initKFid) : mnLastInitKFidMap(initKFid) {
   mpCurrentMap = static_cast<Map*>(NULL);
   CreateNewMap();
 }
@@ -61,9 +60,6 @@ void Atlas::CreateNewMap() {
 
     mpCurrentMap->SetStoredMap();
     cout << "Stored map with ID: " << mpCurrentMap->GetId() << endl;
-
-    // if(mHasViewer)
-    //    mpViewer->AddMapToCreateThumbnail(mpCurrentMap);
   }
   cout << "Creation of new map with last KF id: " << mnLastInitKFidMap << endl;
 
@@ -86,11 +82,6 @@ void Atlas::ChangeMap(Map* pMap) {
 unsigned long int Atlas::GetLastInitKFid() {
   unique_lock<mutex> lock(mMutexAtlas);
   return mnLastInitKFidMap;
-}
-
-void Atlas::SetViewer(Viewer* pViewer) {
-  mpViewer = pViewer;
-  mHasViewer = true;
 }
 
 void Atlas::AddKeyFrame(KeyFrame* pKF) {

--- a/src/Atlas.cc
+++ b/src/Atlas.cc
@@ -206,7 +206,7 @@ Map* Atlas::GetCurrentMap(System* sys) {
   unique_lock<mutex> lock(mMutexAtlas);
   if (!mpCurrentMap) CreateNewMap();
   while (mpCurrentMap->IsBad()) {
-    if (sys != nullptr && sys->isShutDown()) return nullptr;
+    if (sys != nullptr) return nullptr;
   }
 
   return mpCurrentMap;

--- a/src/FrameDrawer.cc
+++ b/src/FrameDrawer.cc
@@ -29,7 +29,7 @@
 
 namespace ORB_SLAM3 {
 
-FrameDrawer::FrameDrawer(Atlas *pAtlas) : both(false), mpAtlas(pAtlas) {
+FrameDrawer::FrameDrawer(const Atlas_ptr &pAtlas) : both(false), mpAtlas(pAtlas) {
   mState = Tracking::SYSTEM_NOT_READY;
   mIm = cv::Mat(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
   mImRight = cv::Mat(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
@@ -322,7 +322,7 @@ void FrameDrawer::DrawTextInfo(cv::Mat &im, int nState, cv::Mat &imText) {
               cv::FONT_HERSHEY_PLAIN, 1, cv::Scalar(255, 255, 255), 1, 8);
 }
 
-void FrameDrawer::Update(Tracking *pTracker) {
+void FrameDrawer::Update(const Tracking_ptr &pTracker) {
   unique_lock<mutex> lock(mMutex);
   pTracker->mImGray.copyTo(mIm);
   mvCurrentKeys = pTracker->mCurrentFrame.mvKeys;

--- a/src/FrameDrawer.cc
+++ b/src/FrameDrawer.cc
@@ -30,7 +30,7 @@
 
 namespace ORB_SLAM3 {
 
-FrameDrawer::FrameDrawer(const Atlas_ptr &pAtlas) : both(false), mpAtlas(pAtlas) {
+FrameDrawer::FrameDrawer(const Atlas_ptr &pAtlas) : mpAtlas(pAtlas), both(false) {
   mState = Tracker::SYSTEM_NOT_READY;
   mIm = cv::Mat(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
   mImRight = cv::Mat(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -32,7 +32,7 @@
 
 namespace ORB_SLAM3 {
 
-LocalMapping::LocalMapping(System* pSys, Atlas* pAtlas, const float bMonocular,
+LocalMapping::LocalMapping(System* pSys, const Atlas_ptr &pAtlas, const float bMonocular,
                            bool bInertial, const string& _strSeqName)
     : mScale(1.0),
       mInitSect(0),

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -233,7 +233,7 @@ void LocalMapping::Run() {
         if ((mTinit < 50.0f) && mbInertial) {
           if (mpCurrentKeyFrame->GetMap()->isImuInitialized() &&
               mpTracker->mState ==
-                  Tracking::OK)  // Enter here everytime local-mapping is called
+                  Tracker::OK)  // Enter here everytime local-mapping is called
           {
             if (!mpCurrentKeyFrame->GetMap()->GetIniertialBA1()) {
               if (mTinit > 5.0f) {
@@ -466,7 +466,7 @@ void LocalMapping::CreateNewMapPoints() {
 
     // Search matches that fullfil epipolar constraint
     vector<pair<size_t, size_t>> vMatchedIndices;
-    bool bCoarse = mbInertial && mpTracker->mState == Tracking::RECENTLY_LOST &&
+    bool bCoarse = mbInertial && mpTracker->mState == Tracker::RECENTLY_LOST &&
                    mpCurrentKeyFrame->GetMap()->GetIniertialBA2();
 
     matcher.SearchForTriangulation(mpCurrentKeyFrame, pKF2, vMatchedIndices,
@@ -1350,7 +1350,7 @@ void LocalMapping::InitializeIMU(float priorG, float priorA, bool bFIBA) {
   }
   mlNewKeyFrames.clear();
 
-  mpTracker->mState = Tracking::OK;
+  mpTracker->mState = Tracker::OK;
   bInitializing = false;
 
   mpCurrentKeyFrame->GetMap()->IncreaseChangeIndex();

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <thread>
 
+#include "ImprovedTypes.hpp"
 #include "Converter.h"
 #include "G2oTypes.h"
 #include "ORBmatcher.h"
@@ -32,7 +33,7 @@
 
 namespace ORB_SLAM3 {
 
-LoopClosing::LoopClosing(Atlas* pAtlas, KeyFrameDatabase* pDB,
+LoopClosing::LoopClosing(const Atlas_ptr &pAtlas, KeyFrameDatabase* pDB,
                          ORBVocabulary* pVoc, const bool bFixScale,
                          const bool bActiveLC)
     : 
@@ -108,9 +109,9 @@ void LoopClosing::Run() {
 #endif
       if (bFindedRegion) {
         if (mbMergeDetected) {
-          if ((mpTracker->mSensor == System::IMU_MONOCULAR ||
-               mpTracker->mSensor == System::IMU_STEREO ||
-               mpTracker->mSensor == System::IMU_RGBD) &&
+          if ((mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+               mpTracker->mSensor == CameraType::IMU_STEREO ||
+               mpTracker->mSensor == CameraType::IMU_RGBD) &&
               (!mpCurrentKF->GetMap()->isImuInitialized())) {
             cout << "IMU is not initilized, merge is aborted" << endl;
           } else {
@@ -139,9 +140,9 @@ void LoopClosing::Run() {
                 continue;
               }
               // If inertial, force only yaw
-              if ((mpTracker->mSensor == System::IMU_MONOCULAR ||
-                   mpTracker->mSensor == System::IMU_STEREO ||
-                   mpTracker->mSensor == System::IMU_RGBD) &&
+              if ((mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+                   mpTracker->mSensor == CameraType::IMU_STEREO ||
+                   mpTracker->mSensor == CameraType::IMU_RGBD) &&
                   mpCurrentKF->GetMap()->GetIniertialBA1()) {
                 Eigen::Vector3d phi =
                     LogSO3(mSold_new.rotation().toRotationMatrix());
@@ -167,9 +168,9 @@ void LoopClosing::Run() {
             nMerges += 1;
 #endif
             // TODO UNCOMMENT
-            if (mpTracker->mSensor == System::IMU_MONOCULAR ||
-                mpTracker->mSensor == System::IMU_STEREO ||
-                mpTracker->mSensor == System::IMU_RGBD)
+            if (mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+                mpTracker->mSensor == CameraType::IMU_STEREO ||
+                mpTracker->mSensor == CameraType::IMU_RGBD)
               MergeLocal2();
             else
               MergeLocal();
@@ -235,9 +236,9 @@ void LoopClosing::Run() {
                 fabs(phi(2)) < 0.349f) {
               if (mpCurrentKF->GetMap()->IsInertial()) {
                 // If inertial, force only yaw
-                if ((mpTracker->mSensor == System::IMU_MONOCULAR ||
-                     mpTracker->mSensor == System::IMU_STEREO ||
-                     mpTracker->mSensor == System::IMU_RGBD) &&
+                if ((mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+                     mpTracker->mSensor == CameraType::IMU_STEREO ||
+                     mpTracker->mSensor == CameraType::IMU_RGBD) &&
                     mpCurrentKF->GetMap()->GetIniertialBA2()) {
                   phi(0) = 0;
                   phi(1) = 0;
@@ -337,7 +338,7 @@ bool LoopClosing::NewDetectCommonRegions() {
     return false;
   }
 
-  if (mpTracker->mSensor == System::STEREO &&
+  if (mpTracker->mSensor == CameraType::STEREO &&
       mpLastMap->GetAllKeyFrames().size() < 5)  // 12
   {
     // cout << "LoopClousure: Stereo KF inserted without check: " <<
@@ -558,7 +559,7 @@ bool LoopClosing::DetectAndReffineSim3FromLastKF(
 
     bool bFixedScale =
         mbFixScale;  // TODO CHECK; Solo para el monocular inertial
-    if (mpTracker->mSensor == System::IMU_MONOCULAR &&
+    if (mpTracker->mSensor == CameraType::IMU_MONOCULAR &&
         !pCurrentKF->GetMap()->GetIniertialBA2())
       bFixedScale = false;
     int numOptMatches =
@@ -697,7 +698,7 @@ bool LoopClosing::DetectCommonRegionsFromBoW(
     {
       // Geometric validation
       bool bFixedScale = mbFixScale;
-      if (mpTracker->mSensor == System::IMU_MONOCULAR &&
+      if (mpTracker->mSensor == CameraType::IMU_MONOCULAR &&
           !mpCurrentKF->GetMap()->GetIniertialBA2())
         bFixedScale = false;
 
@@ -781,7 +782,7 @@ bool LoopClosing::DetectCommonRegionsFromBoW(
 
           /* The bool below ('bFixedScale') is UNUSED and since all function calls below do not change state. this is not needed.
           bool bFixedScale = mbFixScale; 
-          if(mpTracker->mSensor==System::IMU_MONOCULAR && !mpCurrentKF->GetMap()->GetIniertialBA2())
+          if(mpTracker->mSensor==CameraType::IMU_MONOCULAR && !mpCurrentKF->GetMap()->GetIniertialBA2())
               bFixedScale=false;
           */
 
@@ -1181,7 +1182,7 @@ void LoopClosing::CorrectLoop() {
   // Optimize graph
   bool bFixedScale = mbFixScale;
   // TODO CHECK; Solo para el monocular inertial
-  if (mpTracker->mSensor == System::IMU_MONOCULAR &&
+  if (mpTracker->mSensor == CameraType::IMU_MONOCULAR &&
       !mpCurrentKF->GetMap()->GetIniertialBA2())
     bFixedScale = false;
 
@@ -1642,9 +1643,9 @@ void LoopClosing::MergeLocal() {
             std::back_inserter(vpLocalCurrentWindowKFs));
   std::copy(spMergeConnectedKFs.begin(), spMergeConnectedKFs.end(),
             std::back_inserter(vpMergeConnectedKFs));
-  if (mpTracker->mSensor == System::IMU_MONOCULAR ||
-      mpTracker->mSensor == System::IMU_STEREO ||
-      mpTracker->mSensor == System::IMU_RGBD) {
+  if (mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+      mpTracker->mSensor == CameraType::IMU_STEREO ||
+      mpTracker->mSensor == CameraType::IMU_RGBD) {
     Optimizer::MergeInertialBA(mpCurrentKF, mpMergeMatchedKF, &bStop,
                                pCurrentMap, vCorrectedSim3);
   } else {
@@ -1673,7 +1674,7 @@ void LoopClosing::MergeLocal() {
 
   if (vpCurrentMapKFs.size() == 0) {
   } else {
-    if (mpTracker->mSensor == System::MONOCULAR) {
+    if (mpTracker->mSensor == CameraType::MONOCULAR) {
       unique_lock<mutex> currentLock(
           pCurrentMap->mMutexMapUpdate);  // We update the current map with the
                                           // Merge information
@@ -1742,7 +1743,7 @@ void LoopClosing::MergeLocal() {
 
     // Optimize graph (and update the loop position for each element form the
     // begining to the end)
-    if (mpTracker->mSensor != System::MONOCULAR) {
+    if (mpTracker->mSensor != CameraType::MONOCULAR) {
       Optimizer::OptimizeEssentialGraph(mpCurrentKF, vpMergeConnectedKFs,
                                         vpLocalCurrentWindowKFs,
                                         vpCurrentMapKFs, vpCurrentMapMPs);
@@ -1890,9 +1891,9 @@ void LoopClosing::MergeLocal2() {
 
   const int numKFnew = pCurrentMap->KeyFramesInMap();
 
-  if ((mpTracker->mSensor == System::IMU_MONOCULAR ||
-       mpTracker->mSensor == System::IMU_STEREO ||
-       mpTracker->mSensor == System::IMU_RGBD) &&
+  if ((mpTracker->mSensor == CameraType::IMU_MONOCULAR ||
+       mpTracker->mSensor == CameraType::IMU_STEREO ||
+       mpTracker->mSensor == CameraType::IMU_RGBD) &&
       !pCurrentMap->GetIniertialBA2()) {
     // Map is not completly initialized
     Eigen::Vector3d bg, ba;

--- a/src/MapDrawer.cc
+++ b/src/MapDrawer.cc
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <mutex>
 
+#include "Atlas.h"
 #include "KeyFrame.h"
 #include "MapPoint.h"
 

--- a/src/MapDrawer.cc
+++ b/src/MapDrawer.cc
@@ -23,6 +23,7 @@
 
 #include <pangolin/pangolin.h>
 
+#include <stdexcept>
 #include <mutex>
 
 #include "KeyFrame.h"
@@ -30,33 +31,25 @@
 
 namespace ORB_SLAM3 {
 
-MapDrawer::MapDrawer(Atlas *pAtlas, const string &strSettingPath,
-                     Settings *settings)
-    : mpAtlas(pAtlas) {
-  if (settings) {
-    newParameterLoader(settings);
-  } else {
+MapDrawer::MapDrawer(const Atlas_ptr &pAtlas, const std::string &strSettingPath): mpAtlas(pAtlas){
     cv::FileStorage fSettings(strSettingPath, cv::FileStorage::READ);
-    bool is_correct = ParseViewerParamFile(fSettings);
-
-    if (!is_correct) {
+    if (!ParseViewerParamFile(fSettings)) {
       std::cerr << "**ERROR in the config file, the format is not correct**"
                 << std::endl;
-      try {
-        throw -1;
-      } catch (exception &e) {
-      }
+      throw std::runtime_error("**ERROR in the config file, the format is not correct**");
     }
-  }
+}
+MapDrawer::MapDrawer(const Atlas_ptr &pAtlas, const Settings& settings): mpAtlas(pAtlas){
+  newParameterLoader(settings);
 }
 
-void MapDrawer::newParameterLoader(Settings *settings) {
-  mKeyFrameSize = settings->keyFrameSize();
-  mKeyFrameLineWidth = settings->keyFrameLineWidth();
-  mGraphLineWidth = settings->graphLineWidth();
-  mPointSize = settings->pointSize();
-  mCameraSize = settings->cameraSize();
-  mCameraLineWidth = settings->cameraLineWidth();
+void MapDrawer::newParameterLoader(const Settings &settings) {
+  mKeyFrameSize = settings.keyFrameSize();
+  mKeyFrameLineWidth = settings.keyFrameLineWidth();
+  mGraphLineWidth = settings.graphLineWidth();
+  mPointSize = settings.pointSize();
+  mCameraSize = settings.cameraSize();
+  mCameraLineWidth = settings.cameraLineWidth();
 }
 
 bool MapDrawer::ParseViewerParamFile(cv::FileStorage &fSettings) {

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -23,13 +23,12 @@
 
 #include "ImprovedTypes.hpp"
 #include <iostream>
+#include <opencv2/opencv.hpp>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/core/persistence.hpp>
 
 #include "CameraModels/KannalaBrandt8.h"
 #include "CameraModels/Pinhole.h"
-
-using namespace std;
 
 namespace ORB_SLAM3 {
 
@@ -84,7 +83,7 @@ int Settings::readParameter<int>(cv::FileStorage& fSettings,
 }
 
 template <>
-string Settings::readParameter<string>(cv::FileStorage& fSettings,
+std::string Settings::readParameter<std::string>(cv::FileStorage& fSettings,
                                        const std::string& name, bool& found,
                                        const bool required) {
   cv::FileNode node = fSettings[name];
@@ -96,10 +95,10 @@ string Settings::readParameter<string>(cv::FileStorage& fSettings,
     } else {
       std::cerr << name << " optional parameter does not exist..." << std::endl;
       found = false;
-      return string();
+      return std::string();
     }
   } else if (!node.isString()) {
-    std::cerr << name << " parameter must be a string, aborting..."
+    std::cerr << name << " parameter must be a std::string, aborting..."
               << std::endl;
     exit(-1);
   } else {
@@ -139,64 +138,64 @@ Settings::Settings(const std::string& configFile, const int& sensor)
   // Open settings file
   cv::FileStorage fSettings(configFile, cv::FileStorage::READ);
   if (!fSettings.isOpened()) {
-    cerr << "[ERROR]: could not open configuration file at: " << configFile
-         << endl;
-    cerr << "Aborting..." << endl;
+    std::cerr << "[ERROR]: could not open configuration file at: " << configFile
+         << std::endl;
+    std::cerr << "Aborting..." << std::endl;
 
     exit(-1);
   } else {
-    cout << "Loading settings from " << configFile << endl;
+    std::cout << "Loading settings from " << configFile << std::endl;
   }
 
   // Read first camera
   readCamera1(fSettings);
-  cout << "\t-Loaded camera 1" << endl;
+  std::cout << "\t-Loaded camera 1" << std::endl;
 
   // Read second camera if stereo (not rectified)
-  if (sensor_ == CameraType::STEREO || sensor_ == CameraType::IMU_STEREO) {
+  if (sensor_ == ORB_SLAM3::CameraType::STEREO || sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) {
     readCamera2(fSettings);
-    cout << "\t-Loaded camera 2" << endl;
+    std::cout << "\t-Loaded camera 2" << std::endl;
   }
 
   // Read image info
   readImageInfo(fSettings);
-  cout << "\t-Loaded image info" << endl;
+  std::cout << "\t-Loaded image info" << std::endl;
 
-  if (sensor_ == CameraType::IMU_MONOCULAR || sensor_ == CameraType::IMU_STEREO ||
-      sensor_ == CameraType::IMU_RGBD) {
+  if (sensor_ == ORB_SLAM3::CameraType::IMU_MONOCULAR || sensor_ == ORB_SLAM3::CameraType::IMU_STEREO ||
+      sensor_ == ORB_SLAM3::CameraType::IMU_RGBD) {
     readIMU(fSettings);
-    cout << "\t-Loaded IMU calibration" << endl;
+    std::cout << "\t-Loaded IMU calibration" << std::endl;
   }
 
-  if (sensor_ == CameraType::RGBD || sensor_ == CameraType::IMU_RGBD) {
+  if (sensor_ == ORB_SLAM3::CameraType::RGBD || sensor_ == ORB_SLAM3::CameraType::IMU_RGBD) {
     readRGBD(fSettings);
-    cout << "\t-Loaded RGB-D calibration" << endl;
+    std::cout << "\t-Loaded RGB-D calibration" << std::endl;
   }
 
   readORB(fSettings);
-  cout << "\t-Loaded ORB settings" << endl;
+  std::cout << "\t-Loaded ORB settings" << std::endl;
   readViewer(fSettings);
-  cout << "\t-Loaded viewer settings" << endl;
+  std::cout << "\t-Loaded viewer settings" << std::endl;
   readLoadAndSave(fSettings);
-  cout << "\t-Loaded Atlas settings" << endl;
+  std::cout << "\t-Loaded Atlas settings" << std::endl;
   readOtherParameters(fSettings);
-  cout << "\t-Loaded misc parameters" << endl;
+  std::cout << "\t-Loaded misc parameters" << std::endl;
 
   if (bNeedToRectify_) {
     precomputeRectificationMaps();
-    cout << "\t-Computed rectification maps" << endl;
+    std::cout << "\t-Computed rectification maps" << std::endl;
   }
 
-  cout << "----------------------------------" << endl;
+  std::cout << "----------------------------------" << std::endl;
 }
 
 void Settings::readCamera1(cv::FileStorage& fSettings) {
   bool found;
 
   // Read camera model
-  string cameraModel = readParameter<string>(fSettings, "Camera.type", found);
+  std::string cameraModel = readParameter<std::string>(fSettings, "Camera.type", found);
 
-  vector<float> vCalibration;
+  std::vector<float> vCalibration;
   if (cameraModel == "PinHole") {
     cameraType_ = PinHole;
 
@@ -233,7 +232,7 @@ void Settings::readCamera1(cv::FileStorage& fSettings) {
     }
 
     // Check if we need to correct distortion from the images
-    if ((sensor_ == CameraType::MONOCULAR || sensor_ == CameraType::IMU_MONOCULAR) &&
+    if ((sensor_ == ORB_SLAM3::CameraType::MONOCULAR || sensor_ == ORB_SLAM3::CameraType::IMU_MONOCULAR) &&
         vPinHoleDistorsion1_.size() != 0) {
       bNeedToUndistort_ = true;
     }
@@ -271,24 +270,24 @@ void Settings::readCamera1(cv::FileStorage& fSettings) {
     calibration1_ = new KannalaBrandt8(vCalibration);
     originalCalib1_ = new KannalaBrandt8(vCalibration);
 
-    if (sensor_ == CameraType::STEREO || sensor_ == CameraType::IMU_STEREO) {
+    if (sensor_ == ORB_SLAM3::CameraType::STEREO || sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) {
       int colBegin =
           readParameter<int>(fSettings, "Camera1.overlappingBegin", found);
       int colEnd =
           readParameter<int>(fSettings, "Camera1.overlappingEnd", found);
-      vector<int> vOverlapping = {colBegin, colEnd};
+      std::vector<int> vOverlapping = {colBegin, colEnd};
 
       static_cast<KannalaBrandt8*>(calibration1_)->mvLappingArea = vOverlapping;
     }
   } else {
-    cerr << "Error: " << cameraModel << " not known" << endl;
+    std::cerr << "Error: " << cameraModel << " not known" << std::endl;
     exit(-1);
   }
 }
 
 void Settings::readCamera2(cv::FileStorage& fSettings) {
   bool found;
-  vector<float> vCalibration;
+  std::vector<float> vCalibration;
   if (cameraType_ == PinHole) {
     bNeedToRectify_ = true;
 
@@ -343,7 +342,7 @@ void Settings::readCamera2(cv::FileStorage& fSettings) {
     int colBegin =
         readParameter<int>(fSettings, "Camera2.overlappingBegin", found);
     int colEnd = readParameter<int>(fSettings, "Camera2.overlappingEnd", found);
-    vector<int> vOverlapping = {colBegin, colEnd};
+    std::vector<int> vOverlapping = {colBegin, colEnd};
 
     static_cast<KannalaBrandt8*>(calibration2_)->mvLappingArea = vOverlapping;
   }
@@ -389,7 +388,7 @@ void Settings::readImageInfo(cv::FileStorage& fSettings) {
       calibration1_->setParameter(
           calibration1_->getParameter(3) * scaleRowFactor, 3);
 
-      if ((sensor_ == CameraType::STEREO || sensor_ == CameraType::IMU_STEREO) &&
+      if ((sensor_ == ORB_SLAM3::CameraType::STEREO || sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) &&
           cameraType_ != Rectified) {
         calibration2_->setParameter(
             calibration2_->getParameter(1) * scaleRowFactor, 1);
@@ -413,7 +412,7 @@ void Settings::readImageInfo(cv::FileStorage& fSettings) {
       calibration1_->setParameter(
           calibration1_->getParameter(2) * scaleColFactor, 2);
 
-      if ((sensor_ == CameraType::STEREO || sensor_ == CameraType::IMU_STEREO) &&
+      if ((sensor_ == ORB_SLAM3::CameraType::STEREO || sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) &&
           cameraType_ != Rectified) {
         calibration2_->setParameter(
             calibration2_->getParameter(0) * scaleColFactor, 0);
@@ -505,10 +504,10 @@ void Settings::readViewer(cv::FileStorage& fSettings) {
 void Settings::readLoadAndSave(cv::FileStorage& fSettings) {
   bool found;
 
-  sLoadFrom_ = readParameter<string>(fSettings, "System.LoadAtlasFromFile",
+  sLoadFrom_ = readParameter<std::string>(fSettings, "System.LoadAtlasFromFile",
                                      found, false);
   sSaveto_ =
-      readParameter<string>(fSettings, "System.SaveAtlasToFile", found, false);
+      readParameter<std::string>(fSettings, "System.SaveAtlasToFile", found, false);
 }
 
 void Settings::readOtherParameters(cv::FileStorage& fSettings) {
@@ -555,7 +554,7 @@ void Settings::precomputeRectificationMaps() {
   bf_ = b_ * P1.at<double>(0, 0);
 
   // Update relative pose between camera 1 and IMU if necessary
-  if (sensor_ == CameraType::IMU_STEREO) {
+  if (sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) {
     Eigen::Matrix3f eigenR_r1_u1;
     cv::cv2eigen(R_r1_u1, eigenR_r1_u1);
     Sophus::SE3f T_r1_u1(eigenR_r1_u1, Eigen::Vector3f::Zero());
@@ -563,8 +562,8 @@ void Settings::precomputeRectificationMaps() {
   }
 }
 
-ostream& operator<<(std::ostream& output, const Settings& settings) {
-  output << "SLAM settings: " << endl;
+std::ostream& operator<<(std::ostream& output, const Settings& settings) {
+  output << "SLAM settings: " << std::endl;
 
   output << "\t-Camera 1 parameters (";
   if (settings.cameraType_ == Settings::PinHole ||
@@ -578,18 +577,18 @@ ostream& operator<<(std::ostream& output, const Settings& settings) {
   for (size_t i = 0; i < settings.originalCalib1_->size(); i++) {
     output << " " << settings.originalCalib1_->getParameter(i);
   }
-  output << " ]" << endl;
+  output << " ]" << std::endl;
 
   if (!settings.vPinHoleDistorsion1_.empty()) {
     output << "\t-Camera 1 distortion parameters: [ ";
     for (float d : settings.vPinHoleDistorsion1_) {
       output << " " << d;
     }
-    output << " ]" << endl;
+    output << " ]" << std::endl;
   }
   std::cout << "bout to start camera 2 stuff\n";
-  if (settings.sensor_ == CameraType::STEREO ||
-      settings.sensor_ == CameraType::IMU_STEREO) {
+  if (settings.sensor_ == ORB_SLAM3::CameraType::STEREO ||
+      settings.sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) {
     output << "\t-Camera 2 parameters (";
     if (settings.cameraType_ == Settings::PinHole ||
         settings.cameraType_ == Settings::Rectified) {
@@ -602,53 +601,53 @@ ostream& operator<<(std::ostream& output, const Settings& settings) {
     for (size_t i = 0; i < settings.originalCalib2_->size(); i++) {
       output << " " << settings.originalCalib2_->getParameter(i);
     }
-    output << " ]" << endl;
+    output << " ]" << std::endl;
 
     if (!settings.vPinHoleDistorsion2_.empty()) {
       output << "\t-Camera 1 distortion parameters: [ ";
       for (float d : settings.vPinHoleDistorsion2_) {
         output << " " << d;
       }
-      output << " ]" << endl;
+      output << " ]" << std::endl;
     }
   }
 
   output << "\t-Original image size: [ " << settings.originalImSize_.width
-         << " , " << settings.originalImSize_.height << " ]" << endl;
+         << " , " << settings.originalImSize_.height << " ]" << std::endl;
   output << "\t-Current image size: [ " << settings.newImSize_.width << " , "
-         << settings.newImSize_.height << " ]" << endl;
+         << settings.newImSize_.height << " ]" << std::endl;
 
   if (settings.bNeedToRectify_) {
     output << "\t-Camera 1 parameters after rectification: [ ";
     for (size_t i = 0; i < settings.calibration1_->size(); i++) {
       output << " " << settings.calibration1_->getParameter(i);
     }
-    output << " ]" << endl;
+    output << " ]" << std::endl;
   } else if (settings.bNeedToResize1_) {
     output << "\t-Camera 1 parameters after resize: [ ";
     for (size_t i = 0; i < settings.calibration1_->size(); i++) {
       output << " " << settings.calibration1_->getParameter(i);
     }
-    output << " ]" << endl;
+    output << " ]" << std::endl;
 
-    if ((settings.sensor_ == CameraType::STEREO ||
-         settings.sensor_ == CameraType::IMU_STEREO) &&
+    if ((settings.sensor_ == ORB_SLAM3::CameraType::STEREO ||
+         settings.sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) &&
         settings.cameraType_ == Settings::KannalaBrandt) {
       output << "\t-Camera 2 parameters after resize: [ ";
       for (size_t i = 0; i < settings.calibration2_->size(); i++) {
         output << " " << settings.calibration2_->getParameter(i);
       }
-      output << " ]" << endl;
+      output << " ]" << std::endl;
     }
   }
 
-  output << "\t-Sequence FPS: " << settings.fps_ << endl;
+  output << "\t-Sequence FPS: " << settings.fps_ << std::endl;
 
   // Stereo stuff
-  if (settings.sensor_ == CameraType::STEREO ||
-      settings.sensor_ == CameraType::IMU_STEREO) {
-    output << "\t-Stereo baseline: " << settings.b_ << endl;
-    output << "\t-Stereo depth threshold : " << settings.thDepth_ << endl;
+  if (settings.sensor_ == ORB_SLAM3::CameraType::STEREO ||
+      settings.sensor_ == ORB_SLAM3::CameraType::IMU_STEREO) {
+    output << "\t-Stereo baseline: " << settings.b_ << std::endl;
+    output << "\t-Stereo depth threshold : " << settings.thDepth_ << std::endl;
 
     if (settings.cameraType_ == Settings::KannalaBrandt) {
       auto vOverlapping1 =
@@ -656,32 +655,32 @@ ostream& operator<<(std::ostream& output, const Settings& settings) {
       auto vOverlapping2 =
           static_cast<KannalaBrandt8*>(settings.calibration2_)->mvLappingArea;
       output << "\t-Camera 1 overlapping area: [ " << vOverlapping1[0] << " , "
-             << vOverlapping1[1] << " ]" << endl;
+             << vOverlapping1[1] << " ]" << std::endl;
       output << "\t-Camera 2 overlapping area: [ " << vOverlapping2[0] << " , "
-             << vOverlapping2[1] << " ]" << endl;
+             << vOverlapping2[1] << " ]" << std::endl;
     }
   }
 
-  if (settings.sensor_ == CameraType::IMU_MONOCULAR ||
-      settings.sensor_ == CameraType::IMU_STEREO ||
-      settings.sensor_ == CameraType::IMU_RGBD) {
-    output << "\t-Gyro noise: " << settings.noiseGyro_ << endl;
-    output << "\t-Accelerometer noise: " << settings.noiseAcc_ << endl;
-    output << "\t-Gyro walk: " << settings.gyroWalk_ << endl;
-    output << "\t-Accelerometer walk: " << settings.accWalk_ << endl;
-    output << "\t-IMU frequency: " << settings.imuFrequency_ << endl;
+  if (settings.sensor_ == ORB_SLAM3::CameraType::IMU_MONOCULAR ||
+      settings.sensor_ == ORB_SLAM3::CameraType::IMU_STEREO ||
+      settings.sensor_ == ORB_SLAM3::CameraType::IMU_RGBD) {
+    output << "\t-Gyro noise: " << settings.noiseGyro_ << std::endl;
+    output << "\t-Accelerometer noise: " << settings.noiseAcc_ << std::endl;
+    output << "\t-Gyro walk: " << settings.gyroWalk_ << std::endl;
+    output << "\t-Accelerometer walk: " << settings.accWalk_ << std::endl;
+    output << "\t-IMU frequency: " << settings.imuFrequency_ << std::endl;
   }
 
-  if (settings.sensor_ == CameraType::RGBD ||
-      settings.sensor_ == CameraType::IMU_RGBD) {
-    output << "\t-RGB-D depth map factor: " << settings.depthMapFactor_ << endl;
+  if (settings.sensor_ == ORB_SLAM3::CameraType::RGBD ||
+      settings.sensor_ == ORB_SLAM3::CameraType::IMU_RGBD) {
+    output << "\t-RGB-D depth map factor: " << settings.depthMapFactor_ << std::endl;
   }
 
-  output << "\t-Features per image: " << settings.nFeatures_ << endl;
-  output << "\t-ORB scale factor: " << settings.scaleFactor_ << endl;
-  output << "\t-ORB number of scales: " << settings.nLevels_ << endl;
-  output << "\t-Initial FAST threshold: " << settings.initThFAST_ << endl;
-  output << "\t-Min FAST threshold: " << settings.minThFAST_ << endl;
+  output << "\t-Features per image: " << settings.nFeatures_ << std::endl;
+  output << "\t-ORB scale factor: " << settings.scaleFactor_ << std::endl;
+  output << "\t-ORB number of scales: " << settings.nLevels_ << std::endl;
+  output << "\t-Initial FAST threshold: " << settings.initThFAST_ << std::endl;
+  output << "\t-Min FAST threshold: " << settings.minThFAST_ << std::endl;
 
   return output;
 }

--- a/src/System.cc
+++ b/src/System.cc
@@ -52,8 +52,7 @@ System::System(const string& strVocFile, const string& strSettingsFile,
       mbReset(false),
       mbResetActiveMap(false),
       mbActivateLocalizationMode(false),
-      mbDeactivateLocalizationMode(false),
-      mbShutDown(false) {
+      mbDeactivateLocalizationMode(false) {
   // Output welcome message
   cout << endl
        << "ORB-SLAM3 Copyright (C) 2017-2020 Carlos Campos, Richard Elvira, "
@@ -389,10 +388,10 @@ Sophus::SE3f System::TrackRGBD(const cv::Mat& im, const cv::Mat& depthmap,
 Sophus::SE3f System::TrackMonocular(const cv::Mat& im, const double& timestamp,
                                     const vector<IMU::Point>& vImuMeas,
                                     string filename) {
-  {
-    unique_lock<mutex> lock(mMutexReset);
-    if (mbShutDown) return Sophus::SE3f();
-  }
+  // {
+  //   unique_lock<mutex> lock(mMutexReset);
+  //   if (mbShutDown) return Sophus::SE3f();
+  // }
 
   if (mSensor != CameraType::MONOCULAR && mSensor != CameraType::IMU_MONOCULAR) {
     cerr << "ERROR: you called TrackMonocular but input sensor was not set to "
@@ -525,13 +524,6 @@ System::~System() {
 #ifdef REGISTER_TIMES
   mpTracker->PrintTimeStats();
 #endif
-
-  mbShutDown = true;
-}
-
-bool System::isShutDown() {
-  unique_lock<mutex> lock(mMutexReset);
-  return mbShutDown;
 }
 
 void System::SaveTrajectoryTUM(const string& filename) {

--- a/src/System.cc
+++ b/src/System.cc
@@ -44,11 +44,10 @@ namespace ORB_SLAM3 {
 Verbose::eLevel Verbose::th = Verbose::VERBOSITY_NORMAL;
 
 System::System(const string& strVocFile, const string& strSettingsFile,
-               const eSensor sensor, const bool bUseViewer,
+               const eSensor sensor,
                const string& strSequence)
     : mSensor(sensor),
       mpAtlas(0),
-      mpViewer(static_cast<Viewer*>(NULL)),
       mbReset(false),
       mbResetActiveMap(false),
       mbActivateLocalizationMode(false),
@@ -192,15 +191,11 @@ System::System(const string& strVocFile, const string& strSettingsFile,
   if (mSensor == IMU_STEREO || mSensor == IMU_MONOCULAR || mSensor == IMU_RGBD)
     mpAtlas.SetInertialSensor();
 
-  // Create Drawers. These are used by the Viewer
-  mpFrameDrawer = new FrameDrawer(&mpAtlas);
-  mpMapDrawer = new MapDrawer(&mpAtlas, strSettingsFile, settings_);
-
   // Initialize the Tracking thread
   //(it will live in the main thread of execution, the one that called this
   // constructor)
   cout << "Seq. Name: " << strSequence << endl;
-  mpTracker = new Tracking(this, mpVocabulary, mpFrameDrawer, mpMapDrawer,
+  mpTracker = new Tracking(this, mpVocabulary,
                            &mpAtlas, mpKeyFrameDatabase, strSettingsFile,
                            mSensor, settings_, strSequence);
 
@@ -241,16 +236,13 @@ System::System(const string& strVocFile, const string& strSettingsFile,
   // usleep(10*1000*1000);
 
   // Initialize the Viewer thread and launch
-  if (bUseViewer)
-  // if(false) // TODO
-  {
-    mpViewer = new Viewer(this, mpFrameDrawer, mpMapDrawer, mpTracker,
-                          strSettingsFile, settings_);
-    mptViewer = new thread(&Viewer::Run, mpViewer);
-    mpTracker->SetViewer(mpViewer);
-    mpLoopCloser->mpViewer = mpViewer;
-    mpViewer->both = mpFrameDrawer->both;
-  }
+  // if (bUseViewer)
+  // // if(false) // TODO
+  // {
+  //   mpTracker->SetViewer(mpViewer);
+  //   mpLoopCloser->mpViewer = mpViewer;
+  //   mpViewer->both = mpFrameDrawer->both;
+  // }
 
   // Fix verbosity
   Verbose::SetTh(Verbose::VERBOSITY_QUIET);
@@ -506,7 +498,7 @@ void System::ResetActiveMap() {
   mbResetActiveMap = true;
 }
 
-void System::Shutdown() {
+System::~System() {
   cout << "Shutdown" << endl;
   unique_lock<mutex> lock(mMutexReset);
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -45,7 +45,7 @@ namespace ORB_SLAM3 {
 Verbose::eLevel Verbose::th = Verbose::VERBOSITY_NORMAL;
 
 System::System(const string& strVocFile, const string& strSettingsFile,
-               const eSensor sensor,
+               const CameraType::eSensor sensor,
                const string& strSequence)
     : mSensor(sensor),
       mpAtlas(0),
@@ -71,17 +71,17 @@ System::System(const string& strVocFile, const string& strSettingsFile,
 
   cout << "Input sensor was set to: ";
 
-  if (mSensor == MONOCULAR)
+  if (mSensor == CameraType::MONOCULAR)
     cout << "Monocular" << endl;
-  else if (mSensor == STEREO)
+  else if (mSensor == CameraType::STEREO)
     cout << "Stereo" << endl;
-  else if (mSensor == RGBD)
+  else if (mSensor == CameraType::RGBD)
     cout << "RGB-D" << endl;
-  else if (mSensor == IMU_MONOCULAR)
+  else if (mSensor == CameraType::IMU_MONOCULAR)
     cout << "Monocular-Inertial" << endl;
-  else if (mSensor == IMU_STEREO)
+  else if (mSensor == CameraType::IMU_STEREO)
     cout << "Stereo-Inertial" << endl;
-  else if (mSensor == IMU_RGBD)
+  else if (mSensor == CameraType::IMU_RGBD)
     cout << "RGB-D-Inertial" << endl;
 
   // Check settings file
@@ -189,7 +189,7 @@ System::System(const string& strVocFile, const string& strSettingsFile,
     // usleep(10*1000*1000);
   }
 
-  if (mSensor == IMU_STEREO || mSensor == IMU_MONOCULAR || mSensor == IMU_RGBD)
+  if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_RGBD)
     mpAtlas.SetInertialSensor();
 
   // Initialize the Tracking thread
@@ -202,8 +202,8 @@ System::System(const string& strVocFile, const string& strSettingsFile,
 
   // Initialize the Local Mapping thread and launch
   mpLocalMapper = new LocalMapping(
-      this, &mpAtlas, mSensor == MONOCULAR || mSensor == IMU_MONOCULAR,
-      mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO || mSensor == IMU_RGBD,
+      this, &mpAtlas, mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR,
+      mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD,
       strSequence);
   mptLocalMapping = new thread(&ORB_SLAM3::LocalMapping::Run, mpLocalMapper);
   if (settings_)
@@ -221,7 +221,7 @@ System::System(const string& strVocFile, const string& strSettingsFile,
   // mSensor!=MONOCULAR && mSensor!=IMU_MONOCULAR
   mpLoopCloser =
       new LoopClosing(&mpAtlas, mpKeyFrameDatabase, mpVocabulary,
-                      mSensor != MONOCULAR, activeLC);  // mSensor!=MONOCULAR);
+                      mSensor != CameraType::MONOCULAR, activeLC);  // mSensor!=CameraType::MONOCULAR);
   mptLoopClosing = new thread(&ORB_SLAM3::LoopClosing::Run, mpLoopCloser);
 
   // Set pointers between threads
@@ -242,7 +242,7 @@ Sophus::SE3f System::TrackStereo(const cv::Mat& imLeft, const cv::Mat& imRight,
                                  const double& timestamp,
                                  const vector<IMU::Point>& vImuMeas,
                                  string filename) {
-  if (mSensor != STEREO && mSensor != IMU_STEREO) {
+  if (mSensor != CameraType::STEREO && mSensor != CameraType::IMU_STEREO) {
     cerr << "ERROR: you called TrackStereo but input sensor was not set to "
             "Stereo nor Stereo-Inertial."
          << endl;
@@ -300,7 +300,7 @@ Sophus::SE3f System::TrackStereo(const cv::Mat& imLeft, const cv::Mat& imRight,
     }
   }
 
-  if (mSensor == System::IMU_STEREO)
+  if (mSensor == CameraType::IMU_STEREO)
     for (size_t i_imu = 0; i_imu < vImuMeas.size(); i_imu++)
       mpTracker->GrabImuData(vImuMeas[i_imu]);
 
@@ -322,7 +322,7 @@ Sophus::SE3f System::TrackRGBD(const cv::Mat& im, const cv::Mat& depthmap,
                                const double& timestamp,
                                const vector<IMU::Point>& vImuMeas,
                                string filename) {
-  if (mSensor != RGBD && mSensor != IMU_RGBD) {
+  if (mSensor != CameraType::RGBD && mSensor != CameraType::IMU_RGBD) {
     cerr << "ERROR: you called TrackRGBD but input sensor was not set to RGBD."
          << endl;
     exit(-1);
@@ -372,7 +372,7 @@ Sophus::SE3f System::TrackRGBD(const cv::Mat& im, const cv::Mat& depthmap,
     }
   }
 
-  if (mSensor == System::IMU_RGBD)
+  if (mSensor == CameraType::IMU_RGBD)
     for (size_t i_imu = 0; i_imu < vImuMeas.size(); i_imu++)
       mpTracker->GrabImuData(vImuMeas[i_imu]);
 
@@ -394,7 +394,7 @@ Sophus::SE3f System::TrackMonocular(const cv::Mat& im, const double& timestamp,
     if (mbShutDown) return Sophus::SE3f();
   }
 
-  if (mSensor != MONOCULAR && mSensor != IMU_MONOCULAR) {
+  if (mSensor != CameraType::MONOCULAR && mSensor != CameraType::IMU_MONOCULAR) {
     cerr << "ERROR: you called TrackMonocular but input sensor was not set to "
             "Monocular nor Monocular-Inertial."
          << endl;
@@ -443,7 +443,7 @@ Sophus::SE3f System::TrackMonocular(const cv::Mat& im, const double& timestamp,
     }
   }
 
-  if (mSensor == System::IMU_MONOCULAR)
+  if (mSensor == CameraType::IMU_MONOCULAR)
     for (size_t i_imu = 0; i_imu < vImuMeas.size(); i_imu++)
       mpTracker->GrabImuData(vImuMeas[i_imu]);
 
@@ -536,7 +536,7 @@ bool System::isShutDown() {
 
 void System::SaveTrajectoryTUM(const string& filename) {
   cout << endl << "Saving camera trajectory to " << filename << " ..." << endl;
-  if (mSensor == MONOCULAR) {
+  if (mSensor == CameraType::MONOCULAR) {
     cerr << "ERROR: SaveTrajectoryTUM cannot be used for monocular." << endl;
     return;
   }
@@ -628,7 +628,7 @@ void System::SaveKeyFrameTrajectoryTUM(const string& filename) {
 
 void System::SaveTrajectoryEuRoC(const string& filename) {
   cout << endl << "Saving trajectory to " << filename << " ..." << endl;
-  /*if(mSensor==MONOCULAR)
+  /*if(mSensor==CameraType::MONOCULAR)
   {
       cerr << "ERROR: SaveTrajectoryEuRoC cannot be used for monocular." <<
   endl; return;
@@ -661,7 +661,7 @@ void System::SaveTrajectoryEuRoC(const string& filename) {
   // After a loop closure the first keyframe might not be at the origin.
   Sophus::SE3f
       Twb;  // Can be word to cam0 or world to b depending on IMU or not.
-  if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO || mSensor == IMU_RGBD)
+  if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)
     Twb = vpKFs[0]->GetImuPose();
   else
     Twb = vpKFs[0]->GetPoseInverse();
@@ -724,8 +724,8 @@ void System::SaveTrajectoryEuRoC(const string& filename) {
 
     // cout << "4" << endl;
 
-    if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-        mSensor == IMU_RGBD) {
+    if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD) {
       Sophus::SE3f Twb = (pKF->mImuCalib.mTbc * (*lit) * Trw).inverse();
       Eigen::Quaternionf q = Twb.unit_quaternion();
       Eigen::Vector3f twb = Twb.translation();
@@ -752,7 +752,7 @@ void System::SaveTrajectoryEuRoC(const string& filename, Map* pMap) {
   cout << endl
        << "Saving trajectory of map " << pMap->GetId() << " to " << filename
        << " ..." << endl;
-  /*if(mSensor==MONOCULAR)
+  /*if(mSensor==CameraType::MONOCULAR)
   {
       cerr << "ERROR: SaveTrajectoryEuRoC cannot be used for monocular." <<
   endl; return;
@@ -767,7 +767,7 @@ void System::SaveTrajectoryEuRoC(const string& filename, Map* pMap) {
   // After a loop closure the first keyframe might not be at the origin.
   Sophus::SE3f
       Twb;  // Can be word to cam0 or world to b dependingo on IMU or not.
-  if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO || mSensor == IMU_RGBD)
+  if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)
     Twb = vpKFs[0]->GetImuPose();
   else
     Twb = vpKFs[0]->GetPoseInverse();
@@ -830,8 +830,8 @@ void System::SaveTrajectoryEuRoC(const string& filename, Map* pMap) {
 
     // cout << "4" << endl;
 
-    if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-        mSensor == IMU_RGBD) {
+    if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD) {
       Sophus::SE3f Twb = (pKF->mImuCalib.mTbc * (*lit) * Trw).inverse();
       Eigen::Quaternionf q = Twb.unit_quaternion();
       Eigen::Vector3f twb = Twb.translation();
@@ -858,7 +858,7 @@ void System::SaveTrajectoryEuRoC(const string& filename, Map* pMap) {
 {
 
     cout << endl << "Saving trajectory to " << filename << " ..." << endl;
-    if(mSensor==MONOCULAR)
+    if(mSensor==CameraType::MONOCULAR)
     {
         cerr << "ERROR: SaveTrajectoryEuRoC cannot be used for monocular." <<
 endl; return;
@@ -882,7 +882,7 @@ endl; return;
     // Transform all keyframes so that the first keyframe is at the origin.
     // After a loop closure the first keyframe might not be at the origin.
     Sophus::SE3f Twb; // Can be word to cam0 or world to b dependingo on IMU or
-not. if (mSensor==IMU_MONOCULAR || mSensor==IMU_STEREO || mSensor==IMU_RGBD) Twb
+not. if (mSensor==CameraType::IMU_MONOCULAR || mSensor==CameraType::IMU_STEREO || mSensor==CameraType::IMU_RGBD) Twb
 = vpKFs[0]->GetImuPose_(); else Twb = vpKFs[0]->GetPoseInverse_();
 
     ofstream f;
@@ -954,8 +954,8 @@ world reference
         // cout << "4" << endl;
 
 
-        if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-mSensor==IMU_RGBD)
+        if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+mSensor==CameraType::IMU_RGBD)
         {
             Sophus::SE3f Tbw = pKF->mImuCalib.Tbc_ * (*lit) * Trw;
             Sophus::SE3f Twb = Tbw.inverse();
@@ -1020,8 +1020,8 @@ endl;
 
         if(pKF->isBad())
             continue;
-        if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-mSensor==IMU_RGBD)
+        if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+mSensor==CameraType::IMU_RGBD)
         {
             cv::Mat R = pKF->GetImuRotation().t();
             vector<float> q = Converter::toQuaternion(R);
@@ -1081,8 +1081,8 @@ void System::SaveKeyFrameTrajectoryEuRoC(const string& filename) {
     // pKF->SetPose(pKF->GetPose()*Two);
 
     if (!pKF || pKF->isBad()) continue;
-    if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-        mSensor == IMU_RGBD) {
+    if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD) {
       Sophus::SE3f Twb = pKF->GetImuPose();
       Eigen::Quaternionf q = Twb.unit_quaternion();
       Eigen::Vector3f twb = Twb.translation();
@@ -1120,8 +1120,8 @@ void System::SaveKeyFrameTrajectoryEuRoC(const string& filename, Map* pMap) {
     KeyFrame* pKF = vpKFs[i];
 
     if (!pKF || pKF->isBad()) continue;
-    if (mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO ||
-        mSensor == IMU_RGBD) {
+    if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD) {
       Sophus::SE3f Twb = pKF->GetImuPose();
       Eigen::Quaternionf q = Twb.unit_quaternion();
       Eigen::Vector3f twb = Twb.translation();
@@ -1144,7 +1144,7 @@ void System::SaveKeyFrameTrajectoryEuRoC(const string& filename, Map* pMap) {
 /*void System::SaveTrajectoryKITTI(const string &filename)
 {
     cout << endl << "Saving camera trajectory to " << filename << " ..." <<
-endl; if(mSensor==MONOCULAR)
+endl; if(mSensor==CameraType::MONOCULAR)
     {
         cerr << "ERROR: SaveTrajectoryKITTI cannot be used for monocular." <<
 endl; return;
@@ -1204,7 +1204,7 @@ twc.at<float>(2) << endl;
 
 void System::SaveTrajectoryKITTI(const string& filename) {
   cout << endl << "Saving camera trajectory to " << filename << " ..." << endl;
-  if (mSensor == MONOCULAR) {
+  if (mSensor == CameraType::MONOCULAR) {
     cerr << "ERROR: SaveTrajectoryKITTI cannot be used for monocular." << endl;
     return;
   }

--- a/src/System.cc
+++ b/src/System.cc
@@ -24,6 +24,7 @@
 #include <openssl/md5.h>
 #include <pangolin/pangolin.h>
 
+#include "ImprovedTypes.hpp"
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
@@ -1365,7 +1366,7 @@ bool System::isLost() {
     return false;
   else {
     if ((mpTracker->mState ==
-         Tracking::LOST))  //||(mpTracker->mState==Tracking::RECENTLY_LOST))
+         Tracker::LOST))  //||(mpTracker->mState==Tracker::RECENTLY_LOST))
       return true;
     else
       return false;

--- a/src/System.cc
+++ b/src/System.cc
@@ -44,7 +44,7 @@ namespace ORB_SLAM3 {
 Verbose::eLevel Verbose::th = Verbose::VERBOSITY_NORMAL;
 
 System::System(const string& strVocFile, const string& strSettingsFile,
-               const eSensor sensor, const bool bUseViewer, const int initFr,
+               const eSensor sensor, const bool bUseViewer,
                const string& strSequence)
     : mSensor(sensor),
       mpAtlas(0),
@@ -210,7 +210,6 @@ System::System(const string& strVocFile, const string& strSettingsFile,
       mSensor == IMU_MONOCULAR || mSensor == IMU_STEREO || mSensor == IMU_RGBD,
       strSequence);
   mptLocalMapping = new thread(&ORB_SLAM3::LocalMapping::Run, mpLocalMapper);
-  mpLocalMapper->mInitFr = initFr;
   if (settings_)
     mpLocalMapper->mThFarPoints = settings_->thFarPoints();
   else

--- a/src/System.cc
+++ b/src/System.cc
@@ -234,17 +234,6 @@ System::System(const string& strVocFile, const string& strSettingsFile,
   mpLoopCloser->SetTracker(mpTracker);
   mpLoopCloser->SetLocalMapper(mpLocalMapper);
 
-  // usleep(10*1000*1000);
-
-  // Initialize the Viewer thread and launch
-  // if (bUseViewer)
-  // // if(false) // TODO
-  // {
-  //   mpTracker->SetViewer(mpViewer);
-  //   mpLoopCloser->mpViewer = mpViewer;
-  //   mpViewer->both = mpFrameDrawer->both;
-  // }
-
   // Fix verbosity
   Verbose::SetTh(Verbose::VERBOSITY_QUIET);
 }
@@ -532,9 +521,6 @@ System::~System() {
   // if (mptLoopClosing->joinable()) {
   //   mptLoopClosing->join();
   // }
-
-  /*if(mpViewer)
-      pangolin::BindToContext("ORB-SLAM2: Map Viewer");*/
 
 #ifdef REGISTER_TIMES
   mpTracker->PrintTimeStats();

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -54,9 +54,6 @@ Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer,
       mpKeyFrameDB(pKFDB),
       mbReadyToInitializate(false),
       mpSystem(pSys),
-      mpViewer(NULL),
-      mpFrameDrawer(pFrameDrawer),
-      mpMapDrawer(pMapDrawer),
       bStepByStep(false),
       mpAtlas(pAtlas),
       mpLastKeyFrame(static_cast<KeyFrame*>(NULL)),
@@ -1368,8 +1365,6 @@ void Tracking::SetLocalMapper(LocalMapping* pLocalMapper) {
 void Tracking::SetLoopClosing(LoopClosing* pLoopClosing) {
   mpLoopClosing = pLoopClosing;
 }
-
-void Tracking::SetViewer(Viewer* pViewer) { mpViewer = pViewer; }
 
 void Tracking::SetStepByStep(bool bSet) { bStepByStep = bSet; }
 
@@ -3558,10 +3553,10 @@ bool Tracking::Relocalization() {
 void Tracking::Reset(bool bLocMap) {
   Verbose::PrintMess("System Reseting", Verbose::VERBOSITY_NORMAL);
 
-  if (mpViewer) {
-    mpViewer->RequestStop();
-    while (!mpViewer->isStopped()) usleep(3000);
-  }
+  // if (mpViewer) {
+  //   mpViewer->RequestStop();
+  //   while (!mpViewer->isStopped()) usleep(3000);
+  // }
 
   // Reset Local Mapping
   if (!bLocMap) {
@@ -3606,7 +3601,7 @@ void Tracking::Reset(bool bLocMap) {
   mpLastKeyFrame = static_cast<KeyFrame*>(NULL);
   mvIniMatches.clear();
 
-  if (mpViewer) mpViewer->Release();
+  // if (mpViewer) mpViewer->Release();
 
   Verbose::PrintMess("   End reseting! ", Verbose::VERBOSITY_NORMAL);
 }

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -54,7 +54,6 @@ Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer,
       mpKeyFrameDB(pKFDB),
       mbReadyToInitializate(false),
       mpSystem(pSys),
-      bStepByStep(false),
       mpAtlas(pAtlas),
       mpLastKeyFrame(static_cast<KeyFrame*>(NULL)),
       mnLastRelocFrameId(0),
@@ -1366,10 +1365,6 @@ void Tracking::SetLoopClosing(LoopClosing* pLoopClosing) {
   mpLoopClosing = pLoopClosing;
 }
 
-void Tracking::SetStepByStep(bool bSet) { bStepByStep = bSet; }
-
-bool Tracking::GetStepByStep() { return bStepByStep; }
-
 Sophus::SE3f Tracking::GrabImageStereo(const cv::Mat& imRectLeft,
                                        const cv::Mat& imRectRight,
                                        const double& timestamp,
@@ -1704,11 +1699,6 @@ void Tracking::ResetFrameIMU() {
 }
 
 void Tracking::Track() {
-  if (bStepByStep) {
-    std::cout << "Tracking: Waiting to the next step" << std::endl;
-    while (!mbStep && bStepByStep) usleep(500);
-    mbStep = false;
-  }
 
   if (mpLocalMapper->mbBadImu) {
     cout << "TRACK: Reset map because local mapper set the bad imu flag "
@@ -3608,10 +3598,10 @@ void Tracking::Reset(bool bLocMap) {
 
 void Tracking::ResetActiveMap(bool bLocMap) {
   Verbose::PrintMess("Active map Reseting", Verbose::VERBOSITY_NORMAL);
-  if (mpViewer) {
-    mpViewer->RequestStop();
-    while (!mpViewer->isStopped()) usleep(3000);
-  }
+  // if (mpViewer) {
+  //   mpViewer->RequestStop();
+  //   while (!mpViewer->isStopped()) usleep(3000);
+  // }
 
   Map* pMap = mpAtlas->GetCurrentMap();
 
@@ -3683,7 +3673,7 @@ void Tracking::ResetActiveMap(bool bLocMap) {
 
   mbVelocity = false;
 
-  if (mpViewer) mpViewer->Release();
+  // if (mpViewer) mpViewer->Release();
 
   Verbose::PrintMess("   End reseting! ", Verbose::VERBOSITY_NORMAL);
 }

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -21,12 +21,12 @@
 
 #include "Tracking.h"
 
+#include "ImprovedTypes.hpp"
 #include <chrono>
 #include <iostream>
 #include <mutex>
 
 #include "Converter.h"
-#include "FrameDrawer.h"
 #include "G2oTypes.h"
 #include "GeometricTools.h"
 #include "KannalaBrandt8.h"
@@ -82,8 +82,8 @@ Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer,
     }
 
     bool b_parse_imu = true;
-    if (sensor == System::IMU_MONOCULAR || sensor == System::IMU_STEREO ||
-        sensor == System::IMU_RGBD) {
+    if (sensor == CameraType::IMU_MONOCULAR || sensor == CameraType::IMU_STEREO ||
+        sensor == CameraType::IMU_RGBD) {
       b_parse_imu = ParseIMUParamFile(fSettings);
       if (!b_parse_imu) {
         std::cout << "*Error with the IMU parameters in the config file*"
@@ -579,8 +579,8 @@ void Tracking::newParameterLoader(Settings* settings) {
   mK_(0, 2) = mpCamera->getParameter(2);
   mK_(1, 2) = mpCamera->getParameter(3);
 
-  if ((mSensor == System::STEREO || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::STEREO || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       settings->cameraType() == Settings::KannalaBrandt) {
     mpCamera2 = settings->camera2();
     mpCamera2 = mpAtlas->AddCamera(mpCamera2);
@@ -588,13 +588,13 @@ void Tracking::newParameterLoader(Settings* settings) {
     mTlr = settings->Tlr();
   }
 
-  if (mSensor == System::STEREO || mSensor == System::RGBD ||
-      mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::STEREO || mSensor == CameraType::RGBD ||
+      mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
     mbf = settings->bf();
     mThDepth = settings->b() * settings->thDepth();
   }
 
-  if (mSensor == System::RGBD || mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::RGBD || mSensor == CameraType::IMU_RGBD) {
     mDepthMapFactor = settings->depthMapFactor();
     if (fabs(mDepthMapFactor) < 1e-5)
       mDepthMapFactor = 1;
@@ -616,11 +616,11 @@ void Tracking::newParameterLoader(Settings* settings) {
   mpORBextractorLeft = new ORBextractor(nFeatures, fScaleFactor, nLevels,
                                         fIniThFAST, fMinThFAST);
 
-  if (mSensor == System::STEREO || mSensor == System::IMU_STEREO)
+  if (mSensor == CameraType::STEREO || mSensor == CameraType::IMU_STEREO)
     mpORBextractorRight = new ORBextractor(nFeatures, fScaleFactor, nLevels,
                                            fIniThFAST, fMinThFAST);
 
-  if (mSensor == System::MONOCULAR || mSensor == System::IMU_MONOCULAR)
+  if (mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR)
     mpIniORBextractor = new ORBextractor(5 * nFeatures, fScaleFactor, nLevels,
                                          fIniThFAST, fMinThFAST);
 
@@ -898,8 +898,8 @@ bool Tracking::ParseCamParamFile(cv::FileStorage& fSettings) {
       mK_(1, 2) = cy;
     }
 
-    if (mSensor == System::STEREO || mSensor == System::IMU_STEREO ||
-        mSensor == System::IMU_RGBD) {
+    if (mSensor == CameraType::STEREO || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD) {
       // Right camera
       // Camera calibration parameters
       cv::FileNode node = fSettings["Camera2.fx"];
@@ -1092,8 +1092,8 @@ bool Tracking::ParseCamParamFile(cv::FileStorage& fSettings) {
               << std::endl;
   }
 
-  if (mSensor == System::STEREO || mSensor == System::RGBD ||
-      mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::STEREO || mSensor == CameraType::RGBD ||
+      mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
     cv::FileNode node = fSettings["Camera.bf"];
     if (!node.empty() && node.isReal()) {
       mbf = node.real();
@@ -1124,8 +1124,8 @@ bool Tracking::ParseCamParamFile(cv::FileStorage& fSettings) {
   else
     cout << "- color order: BGR (ignored if grayscale)" << endl;
 
-  if (mSensor == System::STEREO || mSensor == System::RGBD ||
-      mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::STEREO || mSensor == CameraType::RGBD ||
+      mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
     float fx = mpCamera->getParameter(0);
     cv::FileNode node = fSettings["ThDepth"];
     if (!node.empty() && node.isReal()) {
@@ -1140,7 +1140,7 @@ bool Tracking::ParseCamParamFile(cv::FileStorage& fSettings) {
     }
   }
 
-  if (mSensor == System::RGBD || mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::RGBD || mSensor == CameraType::IMU_RGBD) {
     cv::FileNode node = fSettings["DepthMapFactor"];
     if (!node.empty() && node.isReal()) {
       mDepthMapFactor = node.real();
@@ -1225,11 +1225,11 @@ bool Tracking::ParseORBParamFile(cv::FileStorage& fSettings) {
   mpORBextractorLeft = new ORBextractor(nFeatures, fScaleFactor, nLevels,
                                         fIniThFAST, fMinThFAST);
 
-  if (mSensor == System::STEREO || mSensor == System::IMU_STEREO)
+  if (mSensor == CameraType::STEREO || mSensor == CameraType::IMU_STEREO)
     mpORBextractorRight = new ORBextractor(nFeatures, fScaleFactor, nLevels,
                                            fIniThFAST, fMinThFAST);
 
-  if (mSensor == System::MONOCULAR || mSensor == System::IMU_MONOCULAR)
+  if (mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR)
     mpIniORBextractor = new ORBextractor(5 * nFeatures, fScaleFactor, nLevels,
                                          fIniThFAST, fMinThFAST);
 
@@ -1393,19 +1393,19 @@ Sophus::SE3f Tracking::GrabImageStereo(const cv::Mat& imRectLeft,
 
   // cout << "Incoming frame creation" << endl;
 
-  if (mSensor == System::STEREO && !mpCamera2)
+  if (mSensor == CameraType::STEREO && !mpCamera2)
     mCurrentFrame = Frame(mImGray, imGrayRight, timestamp, mpORBextractorLeft,
                           mpORBextractorRight, mpORBVocabulary, mK, mDistCoef,
                           mbf, mThDepth, mpCamera);
-  else if (mSensor == System::STEREO && mpCamera2)
+  else if (mSensor == CameraType::STEREO && mpCamera2)
     mCurrentFrame = Frame(mImGray, imGrayRight, timestamp, mpORBextractorLeft,
                           mpORBextractorRight, mpORBVocabulary, mK, mDistCoef,
                           mbf, mThDepth, mpCamera, mpCamera2, mTlr);
-  else if (mSensor == System::IMU_STEREO && !mpCamera2)
+  else if (mSensor == CameraType::IMU_STEREO && !mpCamera2)
     mCurrentFrame = Frame(mImGray, imGrayRight, timestamp, mpORBextractorLeft,
                           mpORBextractorRight, mpORBVocabulary, mK, mDistCoef,
                           mbf, mThDepth, mpCamera, &mLastFrame, *mpImuCalib);
-  else if (mSensor == System::IMU_STEREO && mpCamera2)
+  else if (mSensor == CameraType::IMU_STEREO && mpCamera2)
     mCurrentFrame =
         Frame(mImGray, imGrayRight, timestamp, mpORBextractorLeft,
               mpORBextractorRight, mpORBVocabulary, mK, mDistCoef, mbf,
@@ -1448,11 +1448,11 @@ Sophus::SE3f Tracking::GrabImageRGBD(const cv::Mat& imRGB, const cv::Mat& imD,
   if ((fabs(mDepthMapFactor - 1.0f) > 1e-5) || imDepth.type() != CV_32F)
     imDepth.convertTo(imDepth, CV_32F, mDepthMapFactor);
 
-  if (mSensor == System::RGBD)
+  if (mSensor == CameraType::RGBD)
     mCurrentFrame =
         Frame(mImGray, imDepth, timestamp, mpORBextractorLeft, mpORBVocabulary,
               mK, mDistCoef, mbf, mThDepth, mpCamera);
-  else if (mSensor == System::IMU_RGBD)
+  else if (mSensor == CameraType::IMU_RGBD)
     mCurrentFrame =
         Frame(mImGray, imDepth, timestamp, mpORBextractorLeft, mpORBVocabulary,
               mK, mDistCoef, mbf, mThDepth, mpCamera, &mLastFrame, *mpImuCalib);
@@ -1485,7 +1485,7 @@ Sophus::SE3f Tracking::GrabImageMonocular(const cv::Mat& im,
       cvtColor(mImGray, mImGray, cv::COLOR_BGRA2GRAY);
   }
 
-  if (mSensor == System::MONOCULAR) {
+  if (mSensor == CameraType::MONOCULAR) {
     if (mState == Tracker::NOT_INITIALIZED || mState == Tracker::NO_IMAGES_YET ||
         (lastID - initID) < mMaxFrames)
       mCurrentFrame =
@@ -1495,7 +1495,7 @@ Sophus::SE3f Tracking::GrabImageMonocular(const cv::Mat& im,
       mCurrentFrame =
           Frame(mImGray, timestamp, mpORBextractorLeft, mpORBVocabulary,
                 mpCamera, mDistCoef, mbf, mThDepth);
-  } else if (mSensor == System::IMU_MONOCULAR) {
+  } else if (mSensor == CameraType::IMU_MONOCULAR) {
     if (mState == Tracker::NOT_INITIALIZED || mState == Tracker::NO_IMAGES_YET) {
       mCurrentFrame =
           Frame(mImGray, timestamp, mpIniORBextractor, mpORBVocabulary,
@@ -1745,8 +1745,8 @@ void Tracking::Track() {
     }
   }
 
-  if ((mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       mpLastKeyFrame)
     mCurrentFrame.SetNewBias(mpLastKeyFrame->GetImuBias());
 
@@ -1756,8 +1756,8 @@ void Tracking::Track() {
 
   mLastProcessedState = mState;
 
-  if ((mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       !mbCreatedMap) {
 #ifdef REGISTER_TIMES
     std::chrono::steady_clock::time_point time_StartPreIMU =
@@ -1790,8 +1790,8 @@ void Tracking::Track() {
   }
 
   if (mState == Tracker::NOT_INITIALIZED) {
-    if (mSensor == System::STEREO || mSensor == System::RGBD ||
-        mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+    if (mSensor == CameraType::STEREO || mSensor == CameraType::RGBD ||
+        mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
       StereoInitialization();
     } else {
       MonocularInitialization();
@@ -1841,8 +1841,8 @@ void Tracking::Track() {
 
         if (!bOK) {
           if (mCurrentFrame.mnId <= (mnLastRelocFrameId + mnFramesToResetIMU) &&
-              (mSensor == System::IMU_MONOCULAR ||
-               mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD)) {
+              (mSensor == CameraType::IMU_MONOCULAR ||
+               mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)) {
             mState = Tracker::LOST;
           } else if (pCurrentMap->KeyFramesInMap() > 10) {
             // cout << "KF in map: " << pCurrentMap->KeyFramesInMap() << endl;
@@ -1858,8 +1858,8 @@ void Tracking::Track() {
                              Verbose::VERBOSITY_NORMAL);
 
           bOK = true;
-          if ((mSensor == System::IMU_MONOCULAR ||
-               mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD)) {
+          if ((mSensor == CameraType::IMU_MONOCULAR ||
+               mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)) {
             if (pCurrentMap->isImuInitialized())
               PredictStateIMU();
             else
@@ -1906,8 +1906,8 @@ void Tracking::Track() {
       // Localization Mode: Local Mapping is deactivated (TODO Not available in
       // inertial mode)
       if (mState == Tracker::LOST) {
-        if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-            mSensor == System::IMU_RGBD)
+        if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+            mSensor == CameraType::IMU_RGBD)
           Verbose::PrintMess("IMU. State LOST", Verbose::VERBOSITY_NORMAL);
         bOK = Relocalization();
       } else {
@@ -1997,8 +1997,8 @@ void Tracking::Track() {
     if (bOK)
       mState = Tracker::OK;
     else if (mState == Tracker::OK) {
-      if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-          mSensor == System::IMU_RGBD) {
+      if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+          mSensor == CameraType::IMU_RGBD) {
         Verbose::PrintMess("Track lost for less than one second...",
                            Verbose::VERBOSITY_NORMAL);
         if (!pCurrentMap->isImuInitialized() ||
@@ -2023,8 +2023,8 @@ void Tracking::Track() {
     // modified)
     if ((mCurrentFrame.mnId < (mnLastRelocFrameId + mnFramesToResetIMU)) &&
         (static_cast<int>(mCurrentFrame.mnId) > mnFramesToResetIMU) &&
-        (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-         mSensor == System::IMU_RGBD) &&
+        (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+         mSensor == CameraType::IMU_RGBD) &&
         pCurrentMap->isImuInitialized()) {
       // TODO check this situation
       Verbose::PrintMess("Saving pointer to frame. imu needs reset...",
@@ -2073,8 +2073,8 @@ void Tracking::Track() {
         mbVelocity = false;
       }
 
-      // if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-      //     mSensor == System::IMU_RGBD)
+      // if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+      //     mSensor == CameraType::IMU_RGBD)
       //   mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
 
       // Clean VO matches
@@ -2105,9 +2105,9 @@ void Tracking::Track() {
       // Check if we need to insert a new keyframe
       // if(bNeedKF && bOK)
       if (bNeedKF && (bOK || (mInsertKFsLost && mState == Tracker::RECENTLY_LOST &&
-                              (mSensor == System::IMU_MONOCULAR ||
-                               mSensor == System::IMU_STEREO ||
-                               mSensor == System::IMU_RGBD))))
+                              (mSensor == CameraType::IMU_MONOCULAR ||
+                               mSensor == CameraType::IMU_STEREO ||
+                               mSensor == CameraType::IMU_RGBD))))
         CreateNewKeyFrame();
 
 #ifdef REGISTER_TIMES
@@ -2138,8 +2138,8 @@ void Tracking::Track() {
         mpSystem->ResetActiveMap();
         return;
       }
-      if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-          mSensor == System::IMU_RGBD)
+      if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+          mSensor == CameraType::IMU_RGBD)
         if (!pCurrentMap->isImuInitialized()) {
           Verbose::PrintMess(
               "Track lost before IMU initialisation, reseting...",
@@ -2190,7 +2190,7 @@ void Tracking::Track() {
 
 void Tracking::StereoInitialization() {
   if (mCurrentFrame.N > 500) {
-    if (mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+    if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
       if (!mCurrentFrame.mpImuPreintegrated || !mLastFrame.mpImuPreintegrated) {
         cout << "not IMU meas" << endl;
         return;
@@ -2211,7 +2211,7 @@ void Tracking::StereoInitialization() {
     }
 
     // Set Frame pose to the origin (In case of inertial SLAM to imu)
-    if (mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+    if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
       Eigen::Matrix3f Rwb0 = mCurrentFrame.mImuCalib.mTcb.rotationMatrix();
       Eigen::Vector3f twb0 = mCurrentFrame.mImuCalib.mTcb.translation();
       Eigen::Vector3f Vwb0;
@@ -2310,7 +2310,7 @@ void Tracking::MonocularInitialization() {
 
       fill(mvIniMatches.begin(), mvIniMatches.end(), -1);
 
-      if (mSensor == System::IMU_MONOCULAR) {
+      if (mSensor == CameraType::IMU_MONOCULAR) {
         if (mpImuPreintegratedFromLastKF) {
           delete mpImuPreintegratedFromLastKF;
         }
@@ -2325,7 +2325,7 @@ void Tracking::MonocularInitialization() {
     }
   } else {
     if (((int)mCurrentFrame.mvKeys.size() <= 100) ||
-        ((mSensor == System::IMU_MONOCULAR) &&
+        ((mSensor == CameraType::IMU_MONOCULAR) &&
          (mLastFrame.mTimeStamp - mInitialFrame.mTimeStamp > 1.0))) {
       mbReadyToInitializate = false;
 
@@ -2372,7 +2372,7 @@ void Tracking::CreateInitialMapMonocular() {
   KeyFrame* pKFcur =
       new KeyFrame(mCurrentFrame, mpAtlas->GetCurrentMap(), mpKeyFrameDB);
 
-  if (mSensor == System::IMU_MONOCULAR)
+  if (mSensor == CameraType::IMU_MONOCULAR)
     pKFini->mpImuPreintegrated = (IMU::Preintegrated*)(NULL);
 
   pKFini->ComputeBoW();
@@ -2422,7 +2422,7 @@ void Tracking::CreateInitialMapMonocular() {
 
   float medianDepth = pKFini->ComputeSceneMedianDepth(2);
   float invMedianDepth;
-  if (mSensor == System::IMU_MONOCULAR)
+  if (mSensor == CameraType::IMU_MONOCULAR)
     invMedianDepth = 4.0f / medianDepth;  // 4.0f
   else
     invMedianDepth = 1.0f / medianDepth;
@@ -2451,7 +2451,7 @@ void Tracking::CreateInitialMapMonocular() {
     }
   }
 
-  if (mSensor == System::IMU_MONOCULAR) {
+  if (mSensor == CameraType::IMU_MONOCULAR) {
     pKFcur->mPrevKF = pKFini;
     pKFini->mNextKF = pKFcur;
     pKFcur->mpImuPreintegrated = mpImuPreintegratedFromLastKF;
@@ -2502,8 +2502,8 @@ void Tracking::CreateInitialMapMonocular() {
 void Tracking::CreateMapInAtlas() {
   mnLastInitFrameId = mCurrentFrame.mnId;
   mpAtlas->CreateNewMap();
-  if (mSensor == System::IMU_STEREO || mSensor == System::IMU_MONOCULAR ||
-      mSensor == System::IMU_RGBD)
+  if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_MONOCULAR ||
+      mSensor == CameraType::IMU_RGBD)
     mpAtlas->SetInertialSensor();
   mbSetInit = false;
 
@@ -2519,12 +2519,12 @@ void Tracking::CreateMapInAtlas() {
       Verbose::VERBOSITY_NORMAL);
   mbVO = false;  // Init value for know if there are enough MapPoints in the
                  // last KF
-  if (mSensor == System::MONOCULAR || mSensor == System::IMU_MONOCULAR) {
+  if (mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR) {
     mbReadyToInitializate = false;
   }
 
-  if ((mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       mpImuPreintegratedFromLastKF) {
     delete mpImuPreintegratedFromLastKF;
     mpImuPreintegratedFromLastKF =
@@ -2604,8 +2604,8 @@ bool Tracking::TrackReferenceKeyFrame() {
     }
   }
 
-  if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-      mSensor == System::IMU_RGBD)
+  if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+      mSensor == CameraType::IMU_RGBD)
     return true;
   else
     return nmatchesMap >= 10;
@@ -2617,8 +2617,8 @@ void Tracking::UpdateLastFrame() {
   Sophus::SE3f Tlr = mlRelativeFramePoses.back();
   mLastFrame.SetPose(Tlr * pRef->GetPose());
 
-  if (mnLastKeyFrameId == mLastFrame.mnId || mSensor == System::MONOCULAR ||
-      mSensor == System::IMU_MONOCULAR || !mbOnlyTracking)
+  if (mnLastKeyFrameId == mLastFrame.mnId || mSensor == CameraType::MONOCULAR ||
+      mSensor == CameraType::IMU_MONOCULAR || !mbOnlyTracking)
     return;
 
   // Create "visual odometry" MapPoints
@@ -2697,14 +2697,14 @@ bool Tracking::TrackWithMotionModel() {
   // Project points seen in previous frame
   int th;
 
-  if (mSensor == System::STEREO)
+  if (mSensor == CameraType::STEREO)
     th = 7;
   else
     th = 15;
 
   int nmatches = matcher.SearchByProjection(
       mCurrentFrame, mLastFrame, th,
-      mSensor == System::MONOCULAR || mSensor == System::IMU_MONOCULAR);
+      mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR);
 
   // If few matches, uses a wider window search
   if (nmatches < 20) {
@@ -2715,15 +2715,15 @@ bool Tracking::TrackWithMotionModel() {
 
     nmatches = matcher.SearchByProjection(
         mCurrentFrame, mLastFrame, 2 * th,
-        mSensor == System::MONOCULAR || mSensor == System::IMU_MONOCULAR);
+        mSensor == CameraType::MONOCULAR || mSensor == CameraType::IMU_MONOCULAR);
     Verbose::PrintMess("Matches with wider search: " + to_string(nmatches),
                        Verbose::VERBOSITY_NORMAL);
   }
 
   if (nmatches < 20) {
     Verbose::PrintMess("Not enough matches!!", Verbose::VERBOSITY_NORMAL);
-    if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-        mSensor == System::IMU_RGBD)
+    if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+        mSensor == CameraType::IMU_RGBD)
       return true;
     else
       return false;
@@ -2758,8 +2758,8 @@ bool Tracking::TrackWithMotionModel() {
     return nmatches > 20;
   }
 
-  if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-      mSensor == System::IMU_RGBD)
+  if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+      mSensor == CameraType::IMU_RGBD)
     return true;
   else
     return nmatchesMap >= 10;
@@ -2827,7 +2827,7 @@ bool Tracking::TrackLocalMap() {
             mnMatchesInliers++;
         } else
           mnMatchesInliers++;
-      } else if (mSensor == System::STEREO)
+      } else if (mSensor == CameraType::STEREO)
         mCurrentFrame.mvpMapPoints[i] = static_cast<MapPoint*>(NULL);
     }
   }
@@ -2841,13 +2841,13 @@ bool Tracking::TrackLocalMap() {
 
   if ((mnMatchesInliers > 10) && (mState == Tracker::RECENTLY_LOST)) return true;
 
-  if (mSensor == System::IMU_MONOCULAR) {
+  if (mSensor == CameraType::IMU_MONOCULAR) {
     if ((mnMatchesInliers < 15 && mpAtlas->isImuInitialized()) ||
         (mnMatchesInliers < 50 && !mpAtlas->isImuInitialized())) {
       return false;
     } else
       return true;
-  } else if (mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+  } else if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
     if (mnMatchesInliers < 15) {
       return false;
     } else
@@ -2861,13 +2861,13 @@ bool Tracking::TrackLocalMap() {
 }
 
 bool Tracking::NeedNewKeyFrame() {
-  if ((mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       !mpAtlas->GetCurrentMap()->isImuInitialized()) {
-    if (mSensor == System::IMU_MONOCULAR &&
+    if (mSensor == CameraType::IMU_MONOCULAR &&
         (mCurrentFrame.mTimeStamp - mpLastKeyFrame->mTimeStamp) >= 0.25)
       return true;
-    else if ((mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) &&
+    else if ((mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) &&
              (mCurrentFrame.mTimeStamp - mpLastKeyFrame->mTimeStamp) >= 0.25)
       return true;
     else
@@ -2878,7 +2878,7 @@ bool Tracking::NeedNewKeyFrame() {
 
   // If Local Mapping is freezed by a Loop Closure do not insert keyframes
   if (mpLocalMapper->isStopped() || mpLocalMapper->stopRequested()) {
-    /*if(mSensor == System::MONOCULAR)
+    /*if(mSensor == CameraType::MONOCULAR)
     {
         std::cout << "NeedNewKeyFrame: localmap stopped" << std::endl;
     }*/
@@ -2907,7 +2907,7 @@ bool Tracking::NeedNewKeyFrame() {
   int nNonTrackedClose = 0;
   int nTrackedClose = 0;
 
-  if (mSensor != System::MONOCULAR && mSensor != System::IMU_MONOCULAR) {
+  if (mSensor != CameraType::MONOCULAR && mSensor != CameraType::IMU_MONOCULAR) {
     int N = (mCurrentFrame.Nleft == -1) ? mCurrentFrame.N : mCurrentFrame.Nleft;
     for (int i = 0; i < N; i++) {
       if (mCurrentFrame.mvDepth[i] > 0 && mCurrentFrame.mvDepth[i] < mThDepth) {
@@ -2932,18 +2932,18 @@ bool Tracking::NeedNewKeyFrame() {
 
   /*int nClosedPoints = nTrackedClose + nNonTrackedClose;
   const int thStereoClosedPoints = 15;
-  if(nClosedPoints < thStereoClosedPoints && (mSensor==System::STEREO ||
-  mSensor==System::IMU_STEREO))
+  if(nClosedPoints < thStereoClosedPoints && (mSensor==CameraType::STEREO ||
+  mSensor==CameraType::IMU_STEREO))
   {
       //Pseudo-monocular, there are not enough close points to be confident
   about the stereo observations. thRefRatio = 0.9f;
   }*/
 
-  if (mSensor == System::MONOCULAR) thRefRatio = 0.9f;
+  if (mSensor == CameraType::MONOCULAR) thRefRatio = 0.9f;
 
   if (mpCamera2) thRefRatio = 0.75f;
 
-  if (mSensor == System::IMU_MONOCULAR) {
+  if (mSensor == CameraType::IMU_MONOCULAR) {
     if (mnMatchesInliers > 350)  // Points tracked from the local map
       thRefRatio = 0.75f;
     else
@@ -2959,8 +2959,8 @@ bool Tracking::NeedNewKeyFrame() {
        bLocalMappingIdle);  // mpLocalMapper->KeyframesInQueue() < 2);
   // Condition 1c: tracking is weak
   const bool c1c =
-      mSensor != System::MONOCULAR && mSensor != System::IMU_MONOCULAR &&
-      mSensor != System::IMU_STEREO && mSensor != System::IMU_RGBD &&
+      mSensor != CameraType::MONOCULAR && mSensor != CameraType::IMU_MONOCULAR &&
+      mSensor != CameraType::IMU_STEREO && mSensor != CameraType::IMU_RGBD &&
       (mnMatchesInliers < nRefMatches * 0.25 || bNeedToInsertClose);
   // Condition 2: Few tracked points compared to reference keyframe. Lots of
   // visual odometry compared to map matches.
@@ -2973,10 +2973,10 @@ bool Tracking::NeedNewKeyFrame() {
   // Temporal condition for Inertial cases
   bool c3 = false;
   if (mpLastKeyFrame) {
-    if (mSensor == System::IMU_MONOCULAR) {
+    if (mSensor == CameraType::IMU_MONOCULAR) {
       if ((mCurrentFrame.mTimeStamp - mpLastKeyFrame->mTimeStamp) >= 0.5)
         c3 = true;
-    } else if (mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD) {
+    } else if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD) {
       if ((mCurrentFrame.mTimeStamp - mpLastKeyFrame->mTimeStamp) >= 0.5)
         c3 = true;
     }
@@ -2986,11 +2986,11 @@ bool Tracking::NeedNewKeyFrame() {
   if ((((mnMatchesInliers < 75) && (mnMatchesInliers > 15)) ||
        mState == Tracker::RECENTLY_LOST) &&
       (mSensor ==
-       System::IMU_MONOCULAR))  // MODIFICATION_2, originally
+       CameraType::IMU_MONOCULAR))  // MODIFICATION_2, originally
                                 // ((((mnMatchesInliers<75) &&
                                 // (mnMatchesInliers>15)) ||
                                 // mState==Tracker::RECENTLY_LOST) && ((mSensor ==
-                                // System::IMU_MONOCULAR)))
+                                // CameraType::IMU_MONOCULAR)))
     c4 = true;
   else
     c4 = false;
@@ -3002,7 +3002,7 @@ bool Tracking::NeedNewKeyFrame() {
       return true;
     } else {
       mpLocalMapper->InterruptBA();
-      if (mSensor != System::MONOCULAR && mSensor != System::IMU_MONOCULAR) {
+      if (mSensor != CameraType::MONOCULAR && mSensor != CameraType::IMU_MONOCULAR) {
         if (mpLocalMapper->KeyframesInQueue() < 3)
           return true;
         else
@@ -3039,14 +3039,14 @@ void Tracking::CreateNewKeyFrame() {
                        Verbose::VERBOSITY_NORMAL);
 
   // Reset preintegration from last KF (Create new object)
-  if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-      mSensor == System::IMU_RGBD) {
+  if (mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+      mSensor == CameraType::IMU_RGBD) {
     mpImuPreintegratedFromLastKF =
         new IMU::Preintegrated(pKF->GetImuBias(), pKF->mImuCalib);
   }
 
-  if (mSensor != System::MONOCULAR &&
-      mSensor != System::IMU_MONOCULAR)  // TODO check if incluide imu_stereo
+  if (mSensor != CameraType::MONOCULAR &&
+      mSensor != CameraType::IMU_MONOCULAR)  // TODO check if incluide imu_stereo
   {
     mCurrentFrame.UpdatePoseMatrices();
     // cout << "create new MPs" << endl;
@@ -3054,7 +3054,7 @@ void Tracking::CreateNewKeyFrame() {
     // We create all those MapPoints whose depth < mThDepth.
     // If there are less than 100 close points we create the 100 closest.
     int maxPoint = 100;
-    if (mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD)
+    if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)
       maxPoint = 100;
 
     vector<pair<float, int>> vDepthIdx;
@@ -3179,15 +3179,15 @@ void Tracking::SearchLocalPoints() {
   if (nToMatch > 0) {
     ORBmatcher matcher(0.8);
     int th = 1;
-    if (mSensor == System::RGBD || mSensor == System::IMU_RGBD) th = 3;
+    if (mSensor == CameraType::RGBD || mSensor == CameraType::IMU_RGBD) th = 3;
     if (mpAtlas->isImuInitialized()) {
       if (mpAtlas->GetCurrentMap()->GetIniertialBA2())
         th = 2;
       else
         th = 6;
     } else if (!mpAtlas->isImuInitialized() &&
-               (mSensor == System::IMU_MONOCULAR ||
-                mSensor == System::IMU_STEREO || mSensor == System::IMU_RGBD)) {
+               (mSensor == CameraType::IMU_MONOCULAR ||
+                mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_RGBD)) {
       th = 10;
     }
 
@@ -3358,8 +3358,8 @@ void Tracking::UpdateLocalKeyFrames() {
   }
 
   // Add 10 last temporal KFs (mainly for IMU)
-  if ((mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-       mSensor == System::IMU_RGBD) &&
+  if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||
+       mSensor == CameraType::IMU_RGBD) &&
       mvpLocalKeyFrames.size() < 80) {
     KeyFrame* tempKeyFrame = mCurrentFrame.mpLastKeyFrame;
 
@@ -3559,8 +3559,8 @@ void Tracking::Reset(bool bLocMap) {
   // Clear Map (this erase MapPoints and KeyFrames)
   mpAtlas->clearAtlas();
   mpAtlas->CreateNewMap();
-  if (mSensor == System::IMU_STEREO || mSensor == System::IMU_MONOCULAR ||
-      mSensor == System::IMU_RGBD)
+  if (mSensor == CameraType::IMU_STEREO || mSensor == CameraType::IMU_MONOCULAR ||
+      mSensor == CameraType::IMU_RGBD)
     mpAtlas->SetInertialSensor();
   mnInitialFrameId = 0;
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -39,8 +39,7 @@ using namespace std;
 
 namespace ORB_SLAM3 {
 
-Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer,
-                   MapDrawer* pMapDrawer, Atlas* pAtlas,
+Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, Atlas* pAtlas,
                    KeyFrameDatabase* pKFDB, const string& strSettingPath,
                    const int sensor, Settings* settings, const string& _nameSeq)
     : mState(Tracker::NO_IMAGES_YET),
@@ -1705,9 +1704,9 @@ void Tracking::Track() {
 
   Map* pCurrentMap = mpAtlas->GetCurrentMap(mpSystem);
   if (!pCurrentMap) {
-    if (!mpSystem->isShutDown()){
-      cout << "ERROR: There is not an active map in the atlas" << endl;
-    }
+    // if (!mpSystem->isShutDown()){
+    //   cout << "ERROR: There is not an active map in the atlas" << endl;
+    // }
     return;
   }
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -39,7 +39,7 @@ using namespace std;
 
 namespace ORB_SLAM3 {
 
-Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, Atlas* pAtlas,
+Tracking::Tracking(System* pSys, ORBVocabulary* pVoc, const Atlas_ptr &pAtlas,
                    KeyFrameDatabase* pKFDB, const string& strSettingPath,
                    const int sensor, Settings* settings, const string& _nameSeq)
     : mState(Tracker::NO_IMAGES_YET),

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -586,8 +586,6 @@ void Tracking::newParameterLoader(Settings* settings) {
     mpCamera2 = mpAtlas->AddCamera(mpCamera2);
 
     mTlr = settings->Tlr();
-
-    mpFrameDrawer->both = true;
   }
 
   if (mSensor == System::STEREO || mSensor == System::RGBD ||
@@ -1050,8 +1048,6 @@ bool Tracking::ParseCamParamFile(cv::FileStorage& fSettings) {
             leftLappingBegin;
         static_cast<KannalaBrandt8*>(mpCamera)->mvLappingArea[1] =
             leftLappingEnd;
-
-        mpFrameDrawer->both = true;
 
         vector<float> vCamCalib2{fx, fy, cx, cy, k1, k2, k3, k4};
         mpCamera2 = new KannalaBrandt8(vCamCalib2);
@@ -2063,9 +2059,9 @@ void Tracking::Track() {
 #endif
 
     // Update drawer
-    mpFrameDrawer->Update(this);
-    if (mCurrentFrame.isSet())
-      mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
+    // mpFrameDrawer->Update(this);
+    // if (mCurrentFrame.isSet())
+    //   mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
 
     if (bOK || mState == Tracker::RECENTLY_LOST) {
       // Update motion model
@@ -2077,9 +2073,9 @@ void Tracking::Track() {
         mbVelocity = false;
       }
 
-      if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
-          mSensor == System::IMU_RGBD)
-        mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
+      // if (mSensor == System::IMU_MONOCULAR || mSensor == System::IMU_STEREO ||
+      //     mSensor == System::IMU_RGBD)
+      //   mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
 
       // Clean VO matches
       for (int i = 0; i < mCurrentFrame.N; i++) {
@@ -2296,7 +2292,7 @@ void Tracking::StereoInitialization() {
 
     mpAtlas->GetCurrentMap()->mvpKeyFrameOrigins.push_back(pKFini);
 
-    mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
+    // mpMapDrawer->SetCurrentCameraPose(mCurrentFrame.GetPose());
 
     mState = Tracker::OK;
   }
@@ -2494,7 +2490,7 @@ void Tracking::CreateInitialMapMonocular() {
 
   mpAtlas->SetReferenceMapPoints(mvpLocalMapPoints);
 
-  mpMapDrawer->SetCurrentCameraPose(pKFcur->GetPose());
+  // mpMapDrawer->SetCurrentCameraPose(pKFcur->GetPose());
 
   mpAtlas->GetCurrentMap()->mvpKeyFrameOrigins.push_back(pKFini);
 
@@ -3543,11 +3539,6 @@ bool Tracking::Relocalization() {
 void Tracking::Reset(bool bLocMap) {
   Verbose::PrintMess("System Reseting", Verbose::VERBOSITY_NORMAL);
 
-  // if (mpViewer) {
-  //   mpViewer->RequestStop();
-  //   while (!mpViewer->isStopped()) usleep(3000);
-  // }
-
   // Reset Local Mapping
   if (!bLocMap) {
     Verbose::PrintMess("Reseting Local Mapper...", Verbose::VERBOSITY_NORMAL);
@@ -3591,17 +3582,11 @@ void Tracking::Reset(bool bLocMap) {
   mpLastKeyFrame = static_cast<KeyFrame*>(NULL);
   mvIniMatches.clear();
 
-  // if (mpViewer) mpViewer->Release();
-
   Verbose::PrintMess("   End reseting! ", Verbose::VERBOSITY_NORMAL);
 }
 
 void Tracking::ResetActiveMap(bool bLocMap) {
   Verbose::PrintMess("Active map Reseting", Verbose::VERBOSITY_NORMAL);
-  // if (mpViewer) {
-  //   mpViewer->RequestStop();
-  //   while (!mpViewer->isStopped()) usleep(3000);
-  // }
 
   Map* pMap = mpAtlas->GetCurrentMap();
 
@@ -3672,8 +3657,6 @@ void Tracking::ResetActiveMap(bool bLocMap) {
   mvIniMatches.clear();
 
   mbVelocity = false;
-
-  // if (mpViewer) mpViewer->Release();
 
   Verbose::PrintMess("   End reseting! ", Verbose::VERBOSITY_NORMAL);
 }

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -23,6 +23,7 @@
 
 #include <pangolin/pangolin.h>
 
+#include "ImprovedTypes.hpp"
 #include <chrono>
 #include <ctime>
 #include <mutex>
@@ -51,7 +52,6 @@ Viewer::Viewer(const System_ptr &pSystem, const std::string &strSettingPath)
       throw std::runtime_error("**ERROR in the config file, the format is not correct**");
     }
     mptViewer = std::thread(&Viewer::Run, this);
-    both = mpFrameDrawer.both;
 }
 
 Viewer::Viewer(const System_ptr &pSystem, const Settings &settings)
@@ -88,8 +88,8 @@ void Viewer::newParameterLoader(const Settings &settings) {
   mViewpointZ = settings.viewPointZ();
   mViewpointF = settings.viewPointF();
 
-  if ((mpTracker->mSensor == System::STEREO || mpTracker->mSensor == System::IMU_STEREO ||
-        mpTracker->mSensor == System::IMU_RGBD || mpTracker->mSensor == System::RGBD) &&
+  if ((mpTracker->mSensor == CameraType::STEREO || mpTracker->mSensor == CameraType::IMU_STEREO ||
+        mpTracker->mSensor == CameraType::IMU_RGBD || mpTracker->mSensor == CameraType::RGBD) &&
         settings.cameraType() == Settings::KannalaBrandt)
         setBoth(true);
 }
@@ -169,8 +169,8 @@ bool Viewer::ParseViewerParamFile(cv::FileStorage &fSettings) {
 
   if(!b_miss_params){
     string sCameraName = fSettings["Camera.type"];
-    if ((mpTracker->mSensor == System::STEREO || mpTracker->mSensor == System::IMU_STEREO ||
-          mpTracker->mSensor == System::IMU_RGBD || mpTracker->mSensor == System::RGBD) &&
+    if ((mpTracker->mSensor == CameraType::STEREO || mpTracker->mSensor == CameraType::IMU_STEREO ||
+          mpTracker->mSensor == CameraType::IMU_RGBD || mpTracker->mSensor == CameraType::RGBD) &&
           sCameraName == "KannalaBrandt8")
           setBoth(true);
   }

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -285,7 +285,7 @@ void Viewer::Run() {
       s_cam.Follow(Twc);
     }
 
-    if (menuTopView && mpMapDrawer->mpAtlas->isImuInitialized()) {
+    if (menuTopView && mpMapDrawer->mpAtlas->isImuInitialized()) { // DEPENDS
       menuTopView = false;
       bCameraView = false;
       s_cam.SetProjectionMatrix(pangolin::ProjectionMatrix(
@@ -296,19 +296,19 @@ void Viewer::Run() {
     }
 
     if (menuLocalizationMode && !bLocalizationMode) {
-      mpSystem->ActivateLocalizationMode();
+      mpSystem->ActivateLocalizationMode(); // DEPENDS
       bLocalizationMode = true;
     } else if (!menuLocalizationMode && bLocalizationMode) {
-      mpSystem->DeactivateLocalizationMode();
+      mpSystem->DeactivateLocalizationMode(); // DEPENDS
       bLocalizationMode = false;
     }
 
     if (menuStepByStep && !bStepByStep) {
       // cout << "Viewer: step by step" << endl;
-      mpTracker->SetStepByStep(true);
+      mpTracker->SetStepByStep(true); // DEPENDS
       bStepByStep = true;
     } else if (!menuStepByStep && bStepByStep) {
-      mpTracker->SetStepByStep(false);
+      mpTracker->SetStepByStep(false); // DEPENDS
       bStepByStep = false;
     }
 
@@ -323,13 +323,13 @@ void Viewer::Run() {
     if (menuShowKeyFrames || menuShowGraph || menuShowInertialGraph ||
         menuShowOptLba)
       mpMapDrawer->DrawKeyFrames(menuShowKeyFrames, menuShowGraph,
-                                 menuShowInertialGraph, menuShowOptLba);
-    if (menuShowPoints) mpMapDrawer->DrawMapPoints();
+                                 menuShowInertialGraph, menuShowOptLba); // DEPENDS
+    if (menuShowPoints) mpMapDrawer->DrawMapPoints(); // DEPENDS
 
     pangolin::FinishFrame();
 
     cv::Mat toShow;
-    cv::Mat im = mpFrameDrawer->DrawFrame(trackedImageScale);
+    cv::Mat im = mpFrameDrawer->DrawFrame(trackedImageScale); // DEPENDS
 
     if (both) {
       cv::Mat imRight = mpFrameDrawer->DrawRightFrame(trackedImageScale);
@@ -365,7 +365,7 @@ void Viewer::Run() {
       if (bLocalizationMode) mpSystem->DeactivateLocalizationMode();
 
       // Stop all threads
-      mpSystem.reset();
+      mpSystem.reset(); // DEPENDS
 
       // Save camera trajectory
 


### PR DESCRIPTION
# Description & Motivation

Fixes #55

This PR updates all of the ORB_SLAM3::Viewer code throughout the project to eliminate general system components from depending on the viewer. It also begins to handle memory and threading for affected objects.

# Changes made

### Changes

- Created new typedefs to more easily handle shared_ptr styled memory management
- Separated enum types from major parent classes to reduce coupling
- Removed Viewer and its drawing components along with function calls from all system components
- Updated the architecture of examples and running the code to have a viewer first mentality which improves headless mode
