### PR TITLE
fix active map reset and imu pose segmentation faults

### DIFF
--- a/src/KeyFrameDatabase.cc
+++ b/src/KeyFrameDatabase.cc
@@ -678,11 +678,15 @@ void KeyFrameDatabase::DetectNBestCandidates(KeyFrame* pKF,
   set<KeyFrame*> spAlreadyAddedKF;
   size_t i = 0;
   list<pair<float, KeyFrame*> >::iterator it = lAccScoreAndMatch.begin();
-  while (i < lAccScoreAndMatch.size() &&
+  while ((i < lAccScoreAndMatch.size()) || (i < lAccScoreAndMatch.size() &&
          (static_cast<int>(vpLoopCand.size()) < nNumCandidates ||
-          static_cast<int>(vpMergeCand.size()) < nNumCandidates)) {
+          static_cast<int>(vpMergeCand.size()) < nNumCandidates))) {
     KeyFrame* pKFi = it->second;
-    if (pKFi->isBad()) continue;
+    if (pKFi->isBad()){
+      i++;
+      it++;
+      continue;
+    }
 
     if (!spAlreadyAddedKF.count(pKFi)) {
       if (pKF->GetMap() == pKFi->GetMap() &&

--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -4965,6 +4965,10 @@ int Optimizer::PoseInertialOptimizationLastFrame(Frame* pFrame, bool bRecInit) {
   ear->setInformation(InfoA);
   optimizer.addEdge(ear);
 
+  if (pFp->mpcpi == nullptr){
+    std::cout << "NO MPCPI" << std::endl;
+    return 0; // nInitialCorrespondences
+  }
   EdgePriorPoseImu* ep = new EdgePriorPoseImu(pFp->mpcpi);
 
   ep->setVertex(0, VPk);


### PR DESCRIPTION
Co-authored-by: Soldann <guotl321@gmail.com>
Co-authored-by: ethanseq <sequeira.ethan@gmail.com>
Co-authored-by: Ryan <ryan.zazo@hotmail.com>

Fixes #62 and #69 

This solves two major segfaults that occur when running the code for extended periods of time, 

# Changes made

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

This change increments the pKFi iterator when detecting bad candidates in KeyFrameDatabase, preventing the LoopClosing thread from getting stuck in an infinite loop. This solves #62 

It also fixes #69 by checking if `pfp->mpcpi` is nullptr and exiting early. These two changes are coupled together because the prior change makes issue #69 much more common.


# Test Plan

Ran an extensive test on the laptop both inside and out of the facility

**Test Configuration**:
* Hardware: Ubuntu 20.04 Laptop
