### PR TITLE
Changed viewer default to follow camera, start at camera view, and sh…

### DIFF
--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -200,13 +200,13 @@ void Viewer::Run() {
 
   pangolin::CreatePanel("menu").SetBounds(0.0, 1.0, 0.0,
                                           pangolin::Attach::Pix(175));
-  pangolin::Var<bool> menuFollowCamera("menu.Follow Camera", false, true);
-  pangolin::Var<bool> menuCamView("menu.Camera View", false, false);
+  pangolin::Var<bool> menuFollowCamera("menu.Follow Camera", true, true);
+  pangolin::Var<bool> menuCamView("menu.Camera View", true, true);
   pangolin::Var<bool> menuTopView("menu.Top View", false, false);
   // pangolin::Var<bool> menuSideView("menu.Side View",false,false);
   pangolin::Var<bool> menuShowPoints("menu.Show Points", true, true);
   pangolin::Var<bool> menuShowKeyFrames("menu.Show KeyFrames", true, true);
-  pangolin::Var<bool> menuShowGraph("menu.Show Graph", false, true);
+  pangolin::Var<bool> menuShowGraph("menu.Show Graph", true, true);
   pangolin::Var<bool> menuShowInertialGraph("menu.Show Inertial Graph", true,
                                             true);
   pangolin::Var<bool> menuLocalizationMode("menu.Localization Mode", false,


### PR DESCRIPTION
# Description & Motivation

Fixes #77 

Changed the default on the pangolin viewer to follow the camera, start at camera view, and show graphs. 

# Changes made

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

https://github.com/Soldann/MORB_SLAM/blob/d9c5251fb3862be5e9a736d5465f275bc1d33ea5/src/Viewer.cc#L203-L204

and 

https://github.com/Soldann/MORB_SLAM/blob/d9c5251fb3862be5e9a736d5465f275bc1d33ea5/src/Viewer.cc#L209


# Test Plan

Can be tested with any branch to confirm the new default view moving forward
