### PR TITLE
Fixes #76 by removing automatic reset after slow frame

### DIFF
--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -54,6 +54,7 @@ LocalMapping::LocalMapping(System* pSys, const Atlas_ptr &pAtlas, const float bM
       mbFinishRequested(false),
       mbFinished(true),
       mpAtlas(pAtlas),
+      mpCurrentKeyFrame(nullptr),
       mbAbortBA(false),
       mbStopped(false),
       mbStopRequested(false),

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -1719,29 +1719,7 @@ void Tracking::Track() {
       mlQueueImuData.clear();
       CreateMapInAtlas();
       return;
-    } else if (mCurrentFrame.mTimeStamp > mLastFrame.mTimeStamp + 1.0) {
-      // cout << mCurrentFrame.mTimeStamp << ", " << mLastFrame.mTimeStamp <<
-      // endl; cout << "id last: " << mLastFrame.mnId << "    id curr: " <<
-      // mCurrentFrame.mnId << endl;
-      if (mpAtlas->isInertial()) {
-        if (mpAtlas->isImuInitialized()) {
-          cout << "Timestamp jump detected. State set to LOST. Reseting IMU "
-                  "integration..."
-               << endl;
-          if (!pCurrentMap->GetIniertialBA2()) {
-            mpSystem->ResetActiveMap();
-          } else {
-            CreateMapInAtlas();
-          }
-        } else {
-          cout << "Timestamp jump detected, before IMU initialization. "
-                  "Reseting..."
-               << endl;
-          mpSystem->ResetActiveMap();
-        }
-        return;
-      }
-    }
+    } 
   }
 
   if ((mSensor == CameraType::IMU_MONOCULAR || mSensor == CameraType::IMU_STEREO ||


### PR DESCRIPTION
Co-authored-by: DavidPetkovsek <david.petkovsek@martinrea.com>

# Description & Motivation

Fixes #76 

No more deadlock with "active reset map" 

# Changes made

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

Removed this section from ```Tracking.cc```

https://github.com/Soldann/MORB_SLAM/blob/79ba517bf6a45949ccf44f1f11dc048ba0006385/src/Tracking.cc#L1722-L1744

Added to ```LocalMapping.cc```

https://github.com/Soldann/MORB_SLAM/blob/aec7dc7931f77ad8716abd48dfee4175c24bed15/src/LocalMapping.cc#L57

# Test Plan

The changes were confirmed to work on 2022-07-22. Another test for confirmation would be beneficial.

