### PR TITLE
make build single-threaded on workflow

### DIFF
--- a/.github/morbslam_installer.sh
+++ b/.github/morbslam_installer.sh
@@ -50,4 +50,6 @@ sudo apt install -y libboost-all-dev libssl-dev
 git clone git@github.com:Soldann/MORB_SLAM.git
 cd MORB_SLAM
 chmod +x build.sh
-./build.sh -j$(nproc)
+./build.sh -j1
+
+

--- a/.github/morbslam_installer.sh
+++ b/.github/morbslam_installer.sh
@@ -50,4 +50,4 @@ sudo apt install -y libboost-all-dev libssl-dev
 git clone git@github.com:Soldann/MORB_SLAM.git
 cd MORB_SLAM
 chmod +x build.sh
-./build.sh -j4
+./build.sh -j8

--- a/.github/morbslam_installer.sh
+++ b/.github/morbslam_installer.sh
@@ -50,6 +50,4 @@ sudo apt install -y libboost-all-dev libssl-dev
 git clone git@github.com:Soldann/MORB_SLAM.git
 cd MORB_SLAM
 chmod +x build.sh
-./build.sh -j1
-
-
+./build.sh -j4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: [ "master", "github-workflow" ]
+    branches: [ "master", "workflow-fix" ]
   pull_request:
     branches: [ "master" ]
 
@@ -72,5 +72,5 @@ jobs:
         # GENERATE_PKGCONFIG: # optional
     
     - name: Build & Install MORB_SLAM
-      run: ./morbslam_installer.sh
+      run: ./.github/morbslam_installer.sh
       

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,17 @@
+if [ $# == "1" ]; then
+    jobs=$1
+else 
+    jobs="-j${nproc}"
+fi
+echo "Using argument ${jobs}"
+
 echo "Configuring and building Thirdparty/DBoW2 ..."
 
 cd Thirdparty/DBoW2
 mkdir build 2> /dev/null
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
+make $(jobs)
 
 cd ../../g2o
 
@@ -13,7 +20,7 @@ echo "Configuring and building Thirdparty/g2o ..."
 mkdir build 2> /dev/null
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
+make $(jobs)
 
 cd ../../Sophus
 
@@ -22,7 +29,7 @@ echo "Configuring and building Thirdparty/Sophus ..."
 mkdir build 2> /dev/null
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
+make $(jobs)
 
 cd ../../../
 
@@ -39,4 +46,4 @@ echo "Configuring and building ORB_SLAM3 ..."
 mkdir build 2> /dev/null
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
-make -j$(nproc)
+make $(jobs)


### PR DESCRIPTION
# Description & Motivation

Fixes github workflows failing due to runners running out of memory

# Changes made

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

Creates a specific `morbslam_installer.sh` file for the github runner to run that uses 8 processors instead of the bash-provided maximum.

# Test Plan

See workflow results
