### PR TITLE
Feature: Docker image for MORB_SLAM

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -65,10 +65,6 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value={{branch}}
-            type=semver,pattern={{version}}
-            
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -6,12 +6,10 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '43 10 * * *'
   push:
     branches: [ "master", "Docker" ]
     # Publish server tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,93 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '43 10 * * *'
+  push:
+    branches: [ "master", "Docker" ]
+    # Publish server tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25
+        with:
+          cosign-release: 'v1.9.0'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -67,6 +67,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value={{branch}}
+            type=semver,pattern={{version}}
+            
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -78,6 +82,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref={{ steps.meta.outputs.tags }}
+          cache-to: type=inline
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ "master", "Docker" ]
     # Publish server tags as releases.
-    tags: [ 'v*' ]
+    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "master" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,100 @@
+
+FROM ubuntu:20.04
+
+########################################################################
+# Running this docker to set up a shared directory and display with the host:
+#
+# To newly create and build this docker image:
+# ============================================
+#
+# Create a directory <container_name>: 
+#    $ mkdir <container_name>
+# Copy this Dockerfile into that directory:
+#    cp Dockerfile <container_name>/.
+# Move to that directory:
+#    $ cd <container_name>
+# To build the docker file (might have to run with sudo 
+#    $ sudo docker build -t <container_name> .
+#
+# To run the image, or run it again retaining its state 
+# =====================================================
+#    but also exporting display from the container and
+#    sharing a directory between host and container:
+#
+# Allow other processes to share the display:
+#    $ xhost +    #Allows or other processes to capture (show) the display
+# Now run the docker (Usually $DISPLAY is :0) and allow use of the camera -- you may need sudo privalage
+#    $ sudo docker run  -it  -e DISPLAY=$DISPLAY  -v /tmp/.X11-unix:/tmp/.X11-unix \
+#                       --device /dev/video0 \
+#                       -v /<path_to_a host_directory>/<directory_on_host>/:/<directory_path/name>/  <container_name>
+#
+# =======================================================
+# Handy docker commands:
+# List all the docker images
+#    $ sudo docker ps -a  
+# If the docker image is stopped (otherwise can skip the first command below if not stopped)
+#    $ sudo docker start <container ID from ps -a above>
+#    $ sudo docker attach <container ID from ps -a above>
+########################################################################
+# This is a docker file which will, from scratch:
+#
+#   * pull in all the dependencies needed for OpenCV 3.2 including python 2 dependencies
+#   * pull in OpenCV 3.2 and opencv_contrib and build them
+#       + executable files end up in opencv-3.2.0/build/bin
+#   * pull in the Learning OpenCV 3 example code and build it
+#       + executable files end up in Learning_OpenCV-3_examples/build
+#   * To get to the top level directory, just type: cd
+#
+# If you just want to do this "by hand" in your home, replace the "RUN"s below with "sudo"
+#
+# This Docker uses the ubuntu 16.04 version of ffmpeg, which is older than the ones in my other dockerfiles.
+# this shouldn't cause you any problems but definitely *DO NOT* use this for generating audiofiles / movies for redistribution.
+#
+# But it is somewhat less capable than the ones in the ffmpeg containers.
+########################################################################
+
+
+# First: get all the dependencies:
+#
+RUN apt-get update
+RUN apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev \
+libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev \
+libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev unzip
+
+RUN apt-get install -y wget
+
+# Just get a simple editor for convienience (you could just cancel this line)
+RUN apt-get install -y vim
+
+
+# Second: get and build OpenCV 4.5
+#
+RUN cd \
+    && wget https://github.com/opencv/opencv/archive/4.5.0.zip \
+    && unzip 4.5.0.zip \
+    && cd opencv-4.5.0 \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make -j8 \
+    && make install \
+    && cd \
+    && rm 4.5.0.zip
+
+
+# Third: install and build opencv_contrib
+#
+RUN cd \
+    && wget https://github.com/opencv/opencv_contrib/archive/4.5.0.zip \
+    && unzip 4.5.0.zip \
+    && cd opencv-3.2.0/build \
+    && cmake -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-4.5.0/modules/ .. \
+    && make -j8 \
+    && make install \
+    && cd ../.. \
+    && rm 4.5.0.zip
+
+RUN cd \
+    && git clone https://github.com/Soldann/MORB_SLAM.git \
+    && cd MORB_SLAM \
+    && ./morbslam_installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ FROM ubuntu:20.04
 # But it is somewhat less capable than the ones in the ffmpeg containers.
 ########################################################################
 
+ENV TZ="America/New_York"
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)
 RUN apt update && apt install -y cmake g++ wget unzip git && mkdir opencv

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,15 @@ RUN git clone https://github.com/stevenlovegrove/Pangolin.git
 #git checkout v0.7
 #git submodule update --init --recursive
 
-RUN cd Pangolin && ./scripts/install_prerequisites.sh -m apt all \
+# install pangolin prerequisites
+RUN apt install -y --no-install-suggests --no-install-recommends \
+    libgl1-mesa-dev libwayland-dev libxkbcommon-dev wayland-protocols libegl1-mesa-dev \
+    libc++-dev libglew-dev libeigen3-dev cmake g++ ninja-build \
+    libjpeg-dev libpng-dev \
+    libavcodec-dev libavutil-dev libavformat-dev libswscale-dev libavdevice-dev \
+    libdc1394-22-dev libraw1394-dev libopenni-dev python3.9-dev python3-distutils
+
+RUN cd Pangolin \
     && cmake -B build \
     && cmake --build build -j12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN git clone https://github.com/stevenlovegrove/Pangolin.git
 #git checkout v0.7
 #git submodule update --init --recursive
 
-RUN cd Pangolin && ./scripts/install_prerequisites.sh -m all \
+RUN cd Pangolin && ./scripts/install_prerequisites.sh -m apt all \
     && cmake -B build \
     && cmake --build build -j12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,13 @@ FROM ubuntu:20.04
 
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)
-RUN apt update && apt install -y cmake g++ wget unzip \
+RUN apt update && apt install -y cmake g++ wget unzip && mkdir opencv
 # Download and unpack sources
-    && mkdir opencv && cd opencv \ 
-    && wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip \
-    && unzip opencv.zip \
+WORKDIR "/opencv"
+RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip \
+    && unzip opencv.zip
 # Create build directory
-    && mkdir -p build && cd build \
+RUN mkdir -p build && cd build \
 # Configure
     && cmake  ../opencv-4.5 \
 # Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,45 +54,18 @@ FROM ubuntu:20.04
 ########################################################################
 
 
-# First: get all the dependencies:
-#
-RUN apt-get update
-RUN apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev \
-libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev \
-libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev unzip
+# Install minimal prerequisites (Ubuntu 18.04 as reference)
+sudo apt update && sudo apt install -y cmake g++ wget unzip
+# Download and unpack sources
+wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip
+unzip opencv.zip
+# Create build directory
+mkdir -p build && cd build
+# Configure
+cmake  ../opencv-4.5
+# Build
+cmake --build .
 
-RUN apt-get install -y wget
-
-# Just get a simple editor for convienience (you could just cancel this line)
-RUN apt-get install -y vim
-
-
-# Second: get and build OpenCV 4.5
-#
-RUN cd \
-    && wget https://github.com/opencv/opencv/archive/4.5.0.zip \
-    && unzip 4.5.0.zip \
-    && cd opencv-4.5.0 \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && make -j8 \
-    && make install \
-    && cd \
-    && rm 4.5.0.zip
-
-
-# Third: install and build opencv_contrib
-#
-RUN cd \
-    && wget https://github.com/opencv/opencv_contrib/archive/4.5.0.zip \
-    && unzip 4.5.0.zip \
-    && cd opencv-3.2.0/build \
-    && cmake -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-4.5.0/modules/ .. \
-    && make -j8 \
-    && make install \
-    && cd ../.. \
-    && rm 4.5.0.zip
 
 RUN cd \
     && git clone https://github.com/Soldann/MORB_SLAM.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p build && cd build \
     && cmake --build . \
     && make install
     
-RUN apt install -y libeigen3-dev
+RUN apt install -y libeigen3-dev libgl1-mesa-dev
 
 RUN cd \
     && git clone https://github.com/Soldann/MORB_SLAM.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir -p build && cd build \
     
 
 #python
-RUN apt install libpython2.7-dev ninja-build libeigen3-dev libsuitesparse-dev qtdeclarative5-dev qt5-qmake libqglviewer-dev-qt5 libceres-dev
+RUN apt install -y libpython2.7-dev ninja-build libeigen3-dev libsuitesparse-dev qtdeclarative5-dev qt5-qmake libqglviewer-dev-qt5 libceres-dev
 
 #pangolin
 RUN apt install -y libglew-dev ffmpeg libavcodec-dev libavutil-dev libavformat-dev libswscale-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev \
 libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev \
-libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev unzip
+libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev unzip
 
 RUN apt-get install -y wget
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p build && cd build \
     && cmake --build . \
     && make install
     
-
+RUN apt install -y libeigen3-dev
 
 RUN cd \
     && git clone https://github.com/Soldann/MORB_SLAM.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM ubuntu:20.04
 
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)
-RUN apt update && sudo apt install -y cmake g++ wget unzip \
+RUN apt update && apt install -y cmake g++ wget unzip \
 # Download and unpack sources
     && mkdir opencv && cd opencv \ 
     && wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,34 @@ RUN mkdir -p build && cd build \
     && cmake --build . \
     && make install
     
-RUN apt install -y libeigen3-dev libgl1-mesa-dev
 
-RUN cd \
-    && git clone https://github.com/Soldann/MORB_SLAM.git \
+#python
+RUN apt install libpython2.7-dev ninja-build libeigen3-dev libsuitesparse-dev qtdeclarative5-dev qt5-qmake libqglviewer-dev-qt5 libceres-dev
+
+#pangolin
+RUN apt install -y libglew-dev ffmpeg libavcodec-dev libavutil-dev libavformat-dev libswscale-dev \
+        libdc1394-22-dev libraw1394-dev \
+        libjpeg-dev libpng-dev libtiff5-dev libopenexr-dev \
+        doxygen python3-pydot python3-pydot-ng
+RUN sudo apt install -y graphviz 
+
+WORKDIR "/Pangolin"
+RUN git clone https://github.com/stevenlovegrove/Pangolin.git
+#git checkout v0.7
+#git submodule update --init --recursive
+
+RUN cd Pangolin && ./scripts/install_prerequisites.sh -m all \
+    && cmake -B build \
+    && cmake --build build -j12
+
+#cmake --build build -t pypangolin_pip_install
+
+
+# morbslam
+RUN apt install -y libboost-all-dev libssl-dev
+
+WORKDIR "/MORB_SLAM"
+
+RUN git clone https://github.com/Soldann/MORB_SLAM.git \
     && cd MORB_SLAM \
-    && ./morbslam_installer.sh
+    && ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN apt install -y libglew-dev ffmpeg libavcodec-dev libavutil-dev libavformat-d
         libdc1394-22-dev libraw1394-dev \
         libjpeg-dev libpng-dev libtiff5-dev libopenexr-dev \
         doxygen python3-pydot python3-pydot-ng
-RUN sudo apt install -y graphviz 
+RUN apt install -y graphviz 
 
 WORKDIR "/Pangolin"
 RUN git clone https://github.com/stevenlovegrove/Pangolin.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,16 +55,19 @@ FROM ubuntu:20.04
 
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)
-sudo apt update && sudo apt install -y cmake g++ wget unzip
+RUN apt update && sudo apt install -y cmake g++ wget unzip \
 # Download and unpack sources
-wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip
-unzip opencv.zip
+    && mkdir opencv && cd opencv \ 
+    && wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip \
+    && unzip opencv.zip \
 # Create build directory
-mkdir -p build && cd build
+    && mkdir -p build && cd build \
 # Configure
-cmake  ../opencv-4.5
+    && cmake  ../opencv-4.5 \
 # Build
-cmake --build .
+    && cmake --build . \
+    && make install
+    
 
 
 RUN cd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,12 +58,12 @@ FROM ubuntu:20.04
 RUN apt update && apt install -y cmake g++ wget unzip && mkdir opencv
 # Download and unpack sources
 WORKDIR "/opencv"
-RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.zip \
+RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.4.zip \
     && unzip opencv.zip
 # Create build directory
 RUN mkdir -p build && cd build \
 # Configure
-    && cmake  ../opencv-4.5 \
+    && cmake  ../opencv-4.5.4 \
 # Build
     && cmake --build . \
     && make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM ubuntu:20.04
 
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)
-RUN apt update && apt install -y cmake g++ wget unzip && mkdir opencv
+RUN apt update && apt install -y cmake g++ wget unzip git && mkdir opencv
 # Download and unpack sources
 WORKDIR "/opencv"
 RUN wget -O opencv.zip https://github.com/opencv/opencv/archive/4.5.4.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ FROM ubuntu:20.04
 # But it is somewhat less capable than the ones in the ffmpeg containers.
 ########################################################################
 
+ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ="America/New_York"
 
 # Install minimal prerequisites (Ubuntu 18.04 as reference)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME} MORB_SLAM::MORB_SLAM)
 
 ![MORBSLAM](images/Morbslam.jpg)
 
+## Docker installation
+
+A Docker image is provided to assist in testing of MORB_SLAM. This image should be used for testing purposes only.
+
+```
+docker pull ghcr.io/soldann/morb_slam:latest
+```
+
+To access usb devices like Realsense cameras from the docker container, you need to run in priviledged mode, ie:
+```
+docker run --privileged morb_slam bash
+```
+
 ----------------------------------
 
 ### V1.0, December 22th, 2021

--- a/morbslam_installer.sh
+++ b/morbslam_installer.sh
@@ -47,7 +47,5 @@ cd ..
 
 # morbslam
 sudo apt install -y libboost-all-dev libssl-dev
-git clone git@github.com:Soldann/MORB_SLAM.git
-cd MORB_SLAM
 chmod +x build.sh
 ./build.sh -j$(nproc)


### PR DESCRIPTION
Added a docker image for MORB_SLAM for fast, portable installation 

# Description & Motivation

Created a dockerfile to quickly and easily setup MORB_SLAM for testing. Any use of MORB_SLAM externally should still go through the native installation process

# Changes made

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Changes

Created Dockerfile, workflow, and removed the git clone from the morb_slam installer

# Test Plan

See workflow result

**Test Configuration**:
* Hardware:
